### PR TITLE
projects: Fix start-release.sh command

### DIFF
--- a/cmd/projects/projects.go
+++ b/cmd/projects/projects.go
@@ -268,7 +268,7 @@ func (pm *ProjectManagement) SyncProjects(ctx context.Context, currVer, nextVer 
 		fmt.Fprintf(os.Stdout, "Next project %q not found, creating it...\n", nextVer)
 		// create project
 		nextProjID, projNumber, err = pm.createProject(ctx, nextVer)
-		fmt.Fprintf(os.Stdout, "Project created for %q, command for release: start-release.sh %s %d\n", nextVer, nextVer, projNumber)
+		fmt.Fprintf(os.Stdout, "Project created for %q, command for release: start-release.sh %s %d\n", nextVer, currVer, projNumber)
 
 		// create all 3 columns
 		nextNeedsColumnID,


### PR DESCRIPTION
This was saying you should try to release the version you're opening for
development, which doesn't make sense. Fix it.
