### PR TITLE
pkg/github: Ignore unfilled release notes

### DIFF
--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -24,6 +24,7 @@ import (
 const (
 	releaseNoteBlock = "```release-note"
 	upstreamPRsBlock = "```upstream-prs"
+	commentTag       = "<!--"
 )
 
 func textBlockBetween(body, str string) string {
@@ -83,7 +84,7 @@ func getUpstreamPRs(body string) []int {
 func getReleaseNote(title, body string) string {
 	if strings.Contains(body, releaseNoteBlock) {
 		block := textBlockBetween(body, releaseNoteBlock)
-		if len(block) != 0 {
+		if len(block) != 0 && !strings.Contains(block, commentTag) {
 			return block
 		}
 	}

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -71,6 +71,14 @@ func Test_getReleaseNote(t *testing.T) {
 			},
 			want: "golang: update to 1.12.15",
 		},
+		{
+			name: "",
+			args: args{
+				title: "Pineapple pizza",
+				body:  "```release-note\r\n<!-- Enter the release note text here if needed or remove this section! -->\n",
+			},
+			want: "Pineapple pizza",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Occasionally, new contributors will submit PRs and fail to fill out the
template. Sometimes it doesn't even make much sense to have a release
note, for instance when updating the USERS.md file or making some minor
change that the PR title already describes. For these cases, detect
whether the default string is in the release note and ignore it in favor
of the PR title instead.
