### PR TITLE
.github: Update templates for crd check automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -28,8 +28,6 @@ assignees: ''
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
   - [ ] Run `contrib/release/start-release.sh X.Y.0 <GH-PROJECT> X.Y-1`
-  - [ ] Run `Documentation/check-crd-compat-table.sh vX.Y` and if needed, follow the
-        instructions.
   - [ ] `rm CHANGELOG.md`
   - [ ] Regenerate the log since the previous release with `prep-changelog.sh <last-patch-release> vX.Y.0`
   - [ ] Check and edit the `CHANGELOG.md` to ensure all PRs have proper release notes

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -31,8 +31,6 @@ assignees: ''
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
   - [ ] Run `contrib/release/start-release.sh`
-  - [ ] Run `Documentation/check-crd-compat-table.sh vX.Y` and if needed, follow the
-        instructions.
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -77,10 +77,9 @@ assignees: ''
     - `git commit -sam "Prepare v1.12 stable branch`
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Run `./contrib/release/start-release.sh vX.Y.Z-rcW`
-  - [ ] Run `Documentation/check-crd-compat-table.sh vX.Y`
-    - [ ] Check the modified file(s) in `Documentation` as it will be necessary
-          to fix them manually. Add a new line for this RC and remove
-          unsupported versions.
+  - [ ] Check the modified schema file(s) in `Documentation` as it will be
+        necessary to fix them manually. Add a new line for this RC and remove
+        unsupported versions.
   - [ ] Fix any duplicate `AUTHORS` entries and verify if it is possible to
         get the real names instead of GitHub usernames.
   - [ ] Add the generated `CHANGELOG.md` file and commit all remaining changes

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -22,10 +22,9 @@ assignees: ''
       [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Run `./contrib/release/start-release.sh vX.Y.Z-rcW`
-  - [ ] Run `Documentation/check-crd-compat-table.sh vX.Y`
-    - [ ] Check the modified file(s) in `Documentation` as it will be necessary
-          to fix them manually. Add a new line for this RC and remove
-          unsupported versions.
+  - [ ] Check the modified schema file(s) in `Documentation` as it will be
+        necessary to fix them manually. Add a new line for this RC and remove
+        unsupported versions.
   - [ ] Fix any duplicate `AUTHORS` entries and verify if it is possible to
         get the real names instead of GitHub usernames.
   - [ ] Commit the `AUTHORS` as well as the documentation files changed by the


### PR DESCRIPTION
Recent commits in cilium/cilium have rendered this step unnecessary for
the most common releases. For RCs and main releases we may still need to
manually fix some things up.
