### PR TITLE
.github: Remove references to v1.9 branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -19,12 +19,8 @@ assignees: ''
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
-  - Cilium v1.10 or later:
-     Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
-     [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
-  - Cilium v1.9:
-     Rebuild the image in DockerHub and submit a PR to update the images.
-     [Instructions](https://docs.cilium.io/en/v1.9/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
+  - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
+    [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
 - [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to automatically
   move any unresolved issues/PRs from old release project into the new
   project. (`W` should be calculation of `Z+1`)

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -20,11 +20,8 @@ assignees: ''
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
-  - Cilium v1.10 or later:
-     Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
-     [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
-  - Cilium v1.7 to v1.9:
-     [Re-trigger a build in quay.io](https://docs.cilium.io/en/v1.9/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
+  - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
+    [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
 - [ ] If stable branch is not created yet. Run:
   - `git fetch origin && git checkout -b origin/vX.Y origin/master`
   - [ ] Update the VERSION file with the last RC released for this stable version


### PR DESCRIPTION
We don't need these steps for making new v1.9 releases any more, since
the Cilium project only creates v1.10, v1.11, v1.12 releases now.
