### PR TITLE
.github: Add pre-tag sanity check to patch releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -30,6 +30,7 @@ assignees: ''
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR
+- [ ] Ask a maintainer if there are any known issues that should hold up the release
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
   - [ ] Pull latest branch locally
   - [ ] Run `contrib/release/tag-release.sh`.


### PR DESCRIPTION
Maintainers typically know whether there is an important outstanding
issue that is being solved, security patches that are queued up but not
merged, or may have access to additional testing dashboards to provide
feedback on the whether the release is "good to go". This step is a
catch all to ask maintainers about these topics and sync up before
triggering the remaining release automation.
