### PR TITLE
Miscellaneous updates to the release templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -103,12 +103,15 @@ assignees: ''
         upcoming PRs are tracked correctly for the next release.
   - [ ] Bump the master testsuite to upgrade from vX.Y branch to master
 - [ ] Notify #development on Slack that deprecated features may now be removed.
-- [ ] Update external tools and guides to point to the new Cilium version:
-  - [ ] [kops]
-  - [ ] [kubespray]
-  - [ ] [network policy]
-  - [ ] [cluster administration networking]
-  - [ ] [cluster administration addons]
+- [ ] This is the list of links for known external installers that depend on
+      the release process. Ideally, work toward updating external tools and
+      guides to point to the new Cilium version. If you find where to submit
+      the update, please add the relevant links to this template.
+  - [kops]
+  - [kubespray]
+  - [network policy]
+  - [cluster administration networking]
+  - [cluster administration addons]
 
 
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags

--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -7,27 +7,40 @@ assignees: ''
 
 ---
 
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
+- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
+- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+
 ## Pre-release
 
 - [ ] Announce in Cilium slack channel #launchpad: `Starting vX.Y.0 release process :ship:`
 - [ ] Create a thread for that message and ping current top-hat to not merge any
       PRs until the release process is complete.
 - [ ] Change directory to the local copy of Cilium repository.
-- [ ] Make sure docker is running.
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository.
 - [ ] Check that there are no [release blockers] for the targeted release version
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
-  - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
-     [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
+  - [ ] Modify the `FORCE_BUILD` environment value in the
+        `images/runtime/Dockerfile` to force a rebuild
+        ([Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images))
 - [ ] Update the upgrade guide and [roadmap](https://github.com/cilium/cilium/blob/master/Documentation/community/roadmap.rst) for any features that changed status.
-- [ ] Execute `release --current-version X.Y.0 --next-dev-version X.Y.1` to automatically
-  move any unresolved issues/PRs from old release project into the new
-  project.
+- [ ] Execute `release --current-version X.Y.0 --next-dev-version X.Y.1` to
+      automatically move any unresolved issues/PRs from old release project
+      into the new project. The `release` binary is located in the
+      [current repository][Cilium release-notes tool].
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
   - [ ] Run `contrib/release/start-release.sh X.Y.0 <GH-PROJECT> X.Y-1`
+        Note that this script produces some files at the root of the Cilium
+        repository, and that these files are required at a later step for
+        tagging the release.
   - [ ] `rm CHANGELOG.md`
   - [ ] Regenerate the log since the previous release with `prep-changelog.sh <last-patch-release> vX.Y.0`
   - [ ] Check and edit the `CHANGELOG.md` to ensure all PRs have proper release notes
@@ -38,16 +51,17 @@ assignees: ''
         'stable' tag from the last stable branch.
 - [ ] Merge PR https://github.com/cilium/cilium/pull/18126
 - [ ] Create and push *both* tags to GitHub (`vX.Y.0`, `X.Y.0`)
-  - Pull latest branch locally and run `contrib/release/tag-release.sh`.
-- [ ] Ask a maintainer to approve the build in the following links (keep the URL
+  - [ ] Pull latest branch locally and run `contrib/release/tag-release.sh`.
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
-  - [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
-  - Check if all docker images are available before announcing the release
-    `make -C install/kubernetes/ check-docker-images`
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+  - [ ] Check if all docker images are available before announcing the release:
+        `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/post-release.sh` to fetch the image
-        digests and submit a PR to update these, use the URL of the GitHub run here.
+  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+        digests and submit a PR to update these, use the `URL` of the GitHub
+        run here
   - [ ] Merge PR https://github.com/cilium/cilium/pull/18136
 - [ ] Update helm charts
   - [ ] Pull latest branch locally into the cilium repository.
@@ -97,17 +111,15 @@ assignees: ''
   - [ ] [cluster administration addons]
 
 
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2FX.Y
 [Cilium release-notes tool]: https://github.com/cilium/release
-[Docker Hub]: https://hub.docker.com/orgs/cilium/repositories
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
-[Stable releases]: https://github.com/cilium/cilium#stable-releases
 [kops]: https://github.com/kubernetes/kops/
 [kubespray]: https://github.com/kubernetes-sigs/kubespray/
 [cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
-[Quick Install]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default.html
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -28,8 +28,8 @@ assignees: ''
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
   - [ ] Modify the `FORCE_BUILD` environment value in the
-    `images/runtime/Dockerfile` to force a rebuild
-    [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images).
+        `images/runtime/Dockerfile` to force a rebuild
+        ([Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images))
 - [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to
       automatically move any unresolved issues/PRs from old release project
       into the new project (`W` should be calculation of `Z+1`). The `release`

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -27,8 +27,9 @@ assignees: ''
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
-  - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
-    [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
+  - [ ] Modify the `FORCE_BUILD` environment value in the
+    `images/runtime/Dockerfile` to force a rebuild
+    [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images).
 - [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to
       automatically move any unresolved issues/PRs from old release project
       into the new project (`W` should be calculation of `Z+1`). The `release`
@@ -47,11 +48,11 @@ assignees: ''
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
   - [ ] Pull latest branch locally
   - [ ] Run `contrib/release/tag-release.sh`.
-- [ ] Ask a maintainer to approve the build in the following links (keep the URL
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
-  - [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
-  - Check if all docker images are available before announcing the release
-    `make -C install/kubernetes/ check-docker-images`
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+  - [ ] Check if all docker images are available before announcing the release:
+        `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
   - [ ] Run `contrib/release/post-release.sh URL` to fetch the image

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -13,6 +13,9 @@ assignees: ''
 - [ ] Export a `GITHUB_TOKEN` that has access to the repository
 - [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
 - [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
+- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
 
 ## Pre-release
 

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -87,16 +87,8 @@ assignees: ''
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2FX.Y
 [Cilium release-notes tool]: https://github.com/cilium/release
-[Docker Hub]: https://hub.docker.com/orgs/cilium/repositories
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
-[Stable releases]: https://github.com/cilium/cilium#stable-releases
 [cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
-[Quick Install]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default.html
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
-[read the docs]: https://readthedocs.org/projects/cilium/
-[active versions]: https://readthedocs.org/projects/cilium/versions/
-[default version]: https://readthedocs.org/dashboard/cilium/advanced/
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
-[security policy]: https://github.com/cilium/cilium/security/policy
 [chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -81,12 +81,6 @@ assignees: ''
 ## Post-release
 
 - [ ] Prepare post-release changes to master branch using `contrib/release/bump-readme.sh`
-- [ ] Update external tools and guides to point to the new Cilium version:
-  - [ ] [kops]
-  - [ ] [kubespray]
-  - [ ] [network policy]
-  - [ ] [cluster administration networking]
-  - [ ] [cluster administration addons]
 
 
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
@@ -97,8 +91,6 @@ assignees: ''
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
 [Stable releases]: https://github.com/cilium/cilium#stable-releases
-[kops]: https://github.com/kubernetes/kops/
-[kubespray]: https://github.com/kubernetes-sigs/kubespray/
 [cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
 [Quick Install]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default.html
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
@@ -107,7 +99,4 @@ assignees: ''
 [default version]: https://readthedocs.org/dashboard/cilium/advanced/
 [docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [security policy]: https://github.com/cilium/cilium/security/policy
-[network policy]: https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/
-[cluster administration networking]: https://kubernetes.io/docs/concepts/cluster-administration/networking/
-[cluster administration addons]: https://kubernetes.io/docs/concepts/cluster-administration/addons/
 [chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -35,7 +35,10 @@ assignees: ''
       binary is located in the [current repository][Cilium release-notes tool].
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
-  - [ ] Run `contrib/release/start-release.sh`
+  - [ ] Run `contrib/release/start-release.sh`.
+        Note that this script produces some files at the root of the Cilium
+        repository, and that these files are required at a later step for
+        tagging the release.
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -29,9 +29,10 @@ assignees: ''
       versions on this branch:
   - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
     [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
-- [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to automatically
-  move any unresolved issues/PRs from old release project into the new
-  project. (`W` should be calculation of `Z+1`)
+- [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to
+      automatically move any unresolved issues/PRs from old release project
+      into the new project (`W` should be calculation of `Z+1`). The `release`
+      binary is located in the [current repository][Cilium release-notes tool].
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
   - [ ] Run `contrib/release/start-release.sh`

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -11,6 +11,7 @@ assignees: ''
 
 - [ ] Depending on your OS, make sure Docker is running
 - [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
 
 ## Pre-release
 
@@ -77,6 +78,7 @@ assignees: ''
   - [ ] [cluster administration addons]
 
 
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2FX.Y
 [Cilium release-notes tool]: https://github.com/cilium/release

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -12,6 +12,7 @@ assignees: ''
 - [ ] Depending on your OS, make sure Docker is running
 - [ ] Export a `GITHUB_TOKEN` that has access to the repository
 - [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
+- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
 
 ## Pre-release
 

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -35,7 +35,8 @@ assignees: ''
       binary is located in the [current repository][Cilium release-notes tool].
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
-  - [ ] Run `contrib/release/start-release.sh`.
+  - [ ] Run `contrib/release/start-release.sh X.Y.Z N`, where `N` is the id of
+        the GitHub project created at the previous step.
         Note that this script produces some files at the root of the Cilium
         repository, and that these files are required at a later step for
         tagging the release.
@@ -53,8 +54,9 @@ assignees: ''
     `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/post-release.sh` to fetch the image
-        digests and submit a PR to update these, use the URL of the GitHub run here.
+  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+        digests and submit a PR to update these, use the `URL` of the GitHub
+        run here
   - [ ] Merge PR
 - [ ] Update helm charts
   - [ ] Pull latest branch locally into the cilium repository.

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -7,14 +7,17 @@ assignees: ''
 
 ---
 
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+
 ## Pre-release
 
 - [ ] Announce in Cilium slack channel #launchpad: `Starting vX.Y.Z release process :ship:`
 - [ ] Create a thread for that message and ping current top-hat to not merge any
       PRs until the release process is complete.
 - [ ] Change directory to the local copy of Cilium repository.
-- [ ] Make sure docker is running.
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository.
 - [ ] Check that there are no [release blockers] for the targeted release version
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
+- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
+- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+
 ## Pre-release
 
 
@@ -14,14 +23,13 @@ assignees: ''
 - [ ] Create a thread for that message and ping current top-hat to not merge any
   PRs until the release process is complete.
 - [ ] Change directory to the local copy of Cilium repository.
-- [ ] Make sure docker is running.
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository.
 - [ ] Check that there are no [release blockers] for the targeted release version
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
-  - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
-    [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
+  - [ ] Modify the `FORCE_BUILD` environment value in the
+        `images/runtime/Dockerfile` to force a rebuild
+        ([Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images))
 - [ ] If stable branch is not created yet. Run:
   - `git fetch origin && git checkout -b origin/vX.Y origin/master`
   - [ ] Update the VERSION file with the last RC released for this stable version
@@ -74,6 +82,9 @@ assignees: ''
     - `git commit -sam "Prepare v1.12 stable branch`
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Run `./contrib/release/start-release.sh vX.Y.Z-rcW`
+        Note that this script produces some files at the root of the Cilium
+        repository, and that these files are required at a later step for
+        tagging the release.
   - [ ] Check the modified schema file(s) in `Documentation` as it will be
         necessary to fix them manually. Add a new line for this RC and remove
         unsupported versions.
@@ -88,15 +99,16 @@ assignees: ''
   - Pull latest branch locally.
   - Check out the commit before the revert and run `contrib/release/tag-release.sh`
     against that commit.
-- [ ] Ask a maintainer to approve the build in the following links (keep the URL
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
-  - [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
-  - Check if all docker images are available before announcing the release
-    `make -C install/kubernetes/ check-docker-images`
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+  - [ ] Check if all docker images are available before announcing the release:
+        `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/post-release.sh` to fetch the image
-        digests and submit a PR to update these, use the URL of the GitHub run here.
+  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+        digests and submit a PR to update these, use the `URL` of the GitHub
+        run here
   - [ ] Merge PR
 - [ ] Update helm charts
   - [ ] Pull latest branch locally into the cilium repository.
@@ -134,7 +146,7 @@ https://github.com/cilium/cilium/releases/tag/vX.Y.Z-rcW
 Thank you for the testing and contributing to the previous RC. There are [vX.Y.Z-rcW OSS docs](https://docs.cilium.io/en/vX.Y.Z-rcW) available if you want to pull this version & try it out.
 ```
 
-[Cilium release-notes tool]: https://github.com/cilium/release
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
 [cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -7,21 +7,32 @@ assignees: ''
 
 ---
 
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
+- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
+- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+
 ## Pre-release
 
 - [ ] Announce in Cilium slack channel #launchpad: `Starting vX.Y.Z-rcW release process :ship:`
 - [ ] Create a thread for that message and ping current top-hat to not merge any
       PRs until the release process is complete.
 - [ ] Change directory to the local copy of Cilium repository.
-- [ ] Make sure docker is running.
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository.
 - [ ] Check that there are no [release blockers] for the targeted release version
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch:
-    - Modify the `FORCE_BUILD` environment value in the `images/runtime/Dockerfile` to force a rebuild.
-      [Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
+    - [ ] Modify the `FORCE_BUILD` environment value in the
+          `images/runtime/Dockerfile` to force a rebuild
+          ([Instructions](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images))
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Run `./contrib/release/start-release.sh vX.Y.Z-rcW`
+        Note that this script produces some files at the root of the Cilium
+        repository, and that these files are required at a later step for
+        tagging the release.
   - [ ] Fix any duplicate `AUTHORS` entries and verify if it is possible to
         get the real names instead of GitHub usernames.
   - [ ] Commit the `AUTHORS` as well as the documentation files changed by the
@@ -37,10 +48,10 @@ assignees: ''
   - Pull latest branch locally.
   - Check out the commit before the revert and run `contrib/release/tag-release.sh`
     against that commit.
-- [ ] Ask a maintainer to approve the build in the following links:
-  - [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
-  - Check if all docker images are available before announcing the release
-    `make -C install/kubernetes/ check-docker-images`
+- [ ] Ask a maintainer to approve the build in the following link:
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+  - [ ] Check if all docker images are available before announcing the release:
+        `make -C install/kubernetes/ check-docker-images`
 - [ ] Update helm charts
   - [ ] Create helm charts artifacts in [Cilium charts] repository using
         [cilium helm release tool] for the `vX.Y.Z-rcW` release and push
@@ -77,7 +88,7 @@ https://github.com/cilium/cilium/releases/tag/vX.Y.Z-rcW
 Thank you for the testing and contributing to the previous RC. There are [vX.Y.Z-rcW OSS docs](https://docs.cilium.io/en/vX.Y.Z-rcW) available if you want to pull this version & try it out.
 ```
 
-[Cilium release-notes tool]: https://github.com/cilium/release
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
 [cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh


### PR DESCRIPTION
This PR contains some updates to the release templates, following the October 2022 patch releases round. Probably easier to review per commit: Each commit brings a single change to the patch release template, then the last commit reports the relevant changes to the other templates too.

Changes can be visualised at https://github.com/qmonnet/release/issues/new/choose.

I have not updated the related docs at docs.cilium.io yet.