### PR TITLE
Remove the step to create a release commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -45,7 +45,7 @@ assignees: ''
   - [ ] Regenerate the log since the previous release with `prep-changelog.sh <last-patch-release> vX.Y.0`
   - [ ] Check and edit the `CHANGELOG.md` to ensure all PRs have proper release notes
   - [ ] Edit the `vX.Y.0-changes.txt` files locally to replace the text with "See CHANGELOG.md for more details"
-  - [ ] Commit all changes with title `Prepare for release vX.Y.0`
+  - [ ] Update the release commit with `git add CHANGELOG.md && git commit --amend --no-edit`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
   - [ ] Add the 'stable' tag as part of the GitHub workflow and remove the
         'stable' tag from the last stable branch.

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -41,7 +41,6 @@ assignees: ''
         Note that this script produces some files at the root of the Cilium
         repository, and that these files are required at a later step for
         tagging the release.
-  - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR
 - [ ] Ask a maintainer if there are any known issues that should hold up the release

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -92,6 +92,7 @@ assignees: ''
         get the real names instead of GitHub usernames.
   - [ ] Add the generated `CHANGELOG.md` file and commit all remaining changes
         with the title `Prepare for release vX.Y.Z-rcW`
+  - [ ] Update the release commit with `git add Documentation AUTHORS CHANGELOG.md && git commit --amend --no-edit`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR
 - [ ] Ping current top-hat that PRs can be merged again.

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -35,10 +35,7 @@ assignees: ''
         tagging the release.
   - [ ] Fix any duplicate `AUTHORS` entries and verify if it is possible to
         get the real names instead of GitHub usernames.
-  - [ ] Commit the `AUTHORS` as well as the documentation files changed by the
-        previous step with title `update AUTHORS and Documentation`.
-  - [ ] Add the generated `CHANGELOG.md` file and commit all remaining changes
-        with the title `Prepare for release vX.Y.Z-rcW`
+  - [ ] Update the release commit with `git add AUTHORS CHANGELOG.md && git commit --amend --no-edit`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
   - [ ] Allow the CI to sanity-check the PR (GitHub actions are enough) and get review
   - [ ] Revert the release commit and re-push


### PR DESCRIPTION
start-release.sh now creates a release commit so this step is no longer needed. If previous steps involve manually editing files, amend the commit with `git commit --amend --no-edit`.

Ref: https://github.com/cilium/cilium/pull/22193
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>