### PR TITLE
Avoid moving pending backports to new project

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,12 @@ var (
 	repoName   string
 	currVer    string
 	nextVer    string
+
+	// forceMovePending lets "pending" backports be moved from one project
+	// to another. By default this is set to false, since most commonly
+	// this is a mistake and the PR should have been previously marked as
+	// "backport-done".
+	forceMovePending bool
 )
 
 func init() {
@@ -66,6 +72,7 @@ func init() {
 	flag.StringVar(&lastStable, "last-stable", "", "When last stable version is set, it will be used to detect if a bug was already backported or not to that particular branch (e.g.: '1.5', '1.6')")
 	flag.StringVar(&stateFile, "state-file", "release-state.json", "When set, it will use the already fetched information from a previous run")
 	flag.StringVar(&repoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
+	flag.BoolVar(&forceMovePending, "force-move-pending-backports", false, "Force move pending backports to the next version's project")
 	flag.Parse()
 
 	if len(base) == 0 && len(currVer) == 0 {
@@ -119,7 +126,7 @@ func main() {
 
 	if len(currVer) != 0 {
 		pm := projects.NewProjectManagement(ghClient, owner, repo)
-		err := pm.SyncProjects(globalCtx, currVer, nextVer)
+		err := pm.SyncProjects(globalCtx, currVer, nextVer, forceMovePending)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to manage project: %s\n", err)
 			os.Exit(-1)


### PR DESCRIPTION
As part of backport tracking, we set labels on PRs and attempt to ensure
that when a backport is "done" for a branch, the labels are set and this
controls which column in the versioned project that the PR ends up in.

When we do a new release, the previous behaviour of this tool was to
move all "pending" backports to the project for the next release
version. However, sometimes an earlier step is missed, which means that
PRs that have already been backported eg to 1.12.4 are marked as
"pending" in 1.12.4. This tool then mistakenly moves them to
"pending to 1.12.5", which is incorrect and confusing.

In the absence of a better system to control these, at least avoid
propagating the mistake in this tool. By default, prevent the release
manager from moving "pending backports" to a new project. There is an
override to allow moving the pending backports if they are *really*
pending, but hopefully this at least stops the release long enough to
make sure the backports are in the right status in the backport.
