### PR TITLE
Work when prompt symbol is missing from upstream-prs block

### DIFF
--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -58,11 +58,13 @@ func getUpstreamPRs(body string) []int {
 		return nil
 	}
 	// typical block contains something among these lines:
-	// $ for pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done
-	if !strings.Contains(body, "$ for pr in") {
+	// for pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done
+	if !strings.Contains(body, "for pr in") {
 		return nil
 	}
-	block = strings.TrimPrefix(block, "$ for pr in")
+	// blocks may contain a prompt symbol before the "for" loop
+	block = strings.TrimPrefix(block, "$ ")
+	block = strings.TrimPrefix(block, "for pr in")
 	bashLines := strings.Split(block, ";")
 	if len(bashLines) < 1 {
 		return nil

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -99,7 +99,7 @@ func Test_getBackportPRs(t *testing.T) {
 		want []int
 	}{
 		{
-			name: "test-1",
+			name: "get all three PRs",
 			args: args{
 				body: "```upstream-prs\r\n$ for pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
@@ -110,7 +110,18 @@ func Test_getBackportPRs(t *testing.T) {
 			},
 		},
 		{
-			name: "test-2",
+			name: "get all three PRs (no prompt symbol)",
+			args: args{
+				body: "```upstream-prs\r\nfor pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
+			},
+			want: []int{
+				9959,
+				9982,
+				10005,
+			},
+		},
+		{
+			name: "get single PR",
 			args: args{
 				body: "```upstream-prs\r\n$ for pr in 9959 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
@@ -119,21 +130,37 @@ func Test_getBackportPRs(t *testing.T) {
 			},
 		},
 		{
-			name: "test-4",
+			name: "get single PR (no prompt symbol)",
+			args: args{
+				body: "```upstream-prs\r\n$ for pr in 9959 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
+			},
+			want: []int{
+				9959,
+			},
+		},
+		{
+			name: "command line pattern missing",
 			args: args{
 				body: "```upstream-prs\r\n$ 9 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
 			want: nil,
 		},
 		{
-			name: "test-5",
+			name: "command line pattern missing (no prompt symbol)",
+			args: args{
+				body: "```upstream-prs\r\n9 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
+			},
+			want: nil,
+		},
+		{
+			name: "command line pattern incomplete",
 			args: args{
 				body: "```upstream-prs\r\npr in 99 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
 			want: nil,
 		},
 		{
-			name: "test-6",
+			name: "unfinished quote section",
 			args: args{
 				body: "```upstream-prs\n$ for pr in 9959 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\nfoo\nbar",
 			},


### PR DESCRIPTION
Some backport managers prefer to remove the prompt symbol ($) from the upstream-prs block in the description of backport PRs, because it makes it easier to copy the command to paste it into a terminal (we can use GitHub's copy button, and then there's no prompt symbol to trim before pasting).

This is not currently compatible with how the release tool works, but we can update it accordingly.

Update the tests with a few related cases, and add real test names to avoid re-numbering all tests.

Reference: https://github.com/cilium/cilium/pull/23515#issuecomment-1427536231