### PR TITLE
release: print PRs from last-stable to stderr

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -294,7 +294,7 @@ func printReleaseNotes(prsWithUpstream types.BackportPRs, listOfPrs types.PullRe
 				continue
 			}
 			if !printedReleaseNoteHeader {
-				fmt.Println(releaseNotes[releaseLabel])
+				fmt.Fprintf(os.Stderr, releaseNotes[releaseLabel])
 				printedReleaseNoteHeader = true
 			}
 			changelogItems = append(
@@ -307,7 +307,7 @@ func printReleaseNotes(prsWithUpstream types.BackportPRs, listOfPrs types.PullRe
 			return strings.ToLower(changelogItems[i]) < strings.ToLower(changelogItems[j])
 		})
 		for _, changeLogItem := range changelogItems {
-			fmt.Println(changeLogItem)
+			fmt.Fprintf(os.Stderr, changeLogItem)
 		}
 	}
 }


### PR DESCRIPTION
Similar to the "NOTE" message, we should also print the PRs that will not be part of the changelog into the stderr, otherwise they might be part of the official changelog in case we are redirecting the output of the release notes creation into a file.

Fixes https://github.com/cilium/release/issues/96