### PR TITLE
.github: add direct link to generate GH token

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Setup preparation
 
 - [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
 - [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
 - [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
 - [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Setup preparation
 
 - [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository. Only classic tokens are
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository. Only classic tokens are
       [supported at the moment][GitHub PAT tracker], the needed scope is `public_repo`.
 - [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
 - [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Setup preparation
 
 - [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
 - [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
 - [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
 - [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Setup preparation
 
 - [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a `GITHUB_TOKEN` that has access to the repository
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
 - [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
 - [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
 - [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:


### PR DESCRIPTION
This link will select the necessary permissions automatically in order to perform the release process.