### PR TITLE
Streamline the readme bump for all release types

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -103,7 +103,6 @@ assignees: ''
 ## Post-release
 
 - [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`.
-      Ensure the table formatting for `Stable Releases` in `README.rst` is not broken.
 
 [GitHub PAT tracker]: https://github.com/orgs/community/discussions/36441
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -141,6 +141,7 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 ```
 - [ ] Bump the development snapshot version in `README.rst` on the main branch
       to point to this release
+- [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`.
 
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -89,8 +89,7 @@ https://github.com/cilium/cilium/releases/tag/vX.Y.Z-rc.W
 
 Thank you for the testing and contributing to the previous RC. There are [vX.Y.Z-rc.W OSS docs](https://docs.cilium.io/en/vX.Y.Z-rc.W) available if you want to pull this version & try it out.
 ```
-- [ ] Bump the development snapshot version in `README.rst` on the main branch
-      to point to this release
+- [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`.
 
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y


### PR DESCRIPTION
Newer changes in the Cilium tree allow the same script to be used for
patch releases and prereleases.

Depends on https://github.com/cilium/cilium/pull/27892
