### PR TITLE
Update backport docs after update-label workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -42,6 +42,10 @@ assignees: ''
     - [ ] Create the specific GH workflow that are only triggered via comment in
           the main branch for the stable version going to be released. You can
           find all of them by running `grep -Rl issue_comment ./.github/workflows/*`
+    - [ ] Create the GH workflow named `Call Backport Label Updater` that is triggered
+          after each Backport PR for the stable branch gets merged. You can copy the workflow
+          yaml file from a previous stable branch and update it replacing all occurrences of
+          the branch version to the newly created one.
     - [ ] Remove all GH workflow that are only triggered via comment from the
           stable branch that is going to be released.
     - [ ] Adjust `maintainers-little-helper.yaml` accordingly the new stable

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -57,21 +57,8 @@ func getUpstreamPRs(body string) []int {
 	if len(block) == 0 {
 		return nil
 	}
-	// typical block contains something among these lines:
-	// for pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done
-	if !strings.Contains(body, "for pr in") {
-		return nil
-	}
-	// blocks may contain a prompt symbol before the "for" loop
-	block = strings.TrimPrefix(block, "$ ")
-	block = strings.TrimPrefix(block, "for pr in")
-	bashLines := strings.Split(block, ";")
-	if len(bashLines) < 1 {
-		return nil
-	}
-	strNumbers := strings.Split(bashLines[0], " ")
 	var prNumbers []int
-	for _, strNumber := range strNumbers {
+	for _, strNumber := range strings.Fields(block) {
 		prNumber, err := strconv.Atoi(strNumber)
 		if err != nil {
 			continue


### PR DESCRIPTION
After the introduction of the GH workflow Backport Label Updater, there is no need to manually update the labels of each Backport PR in OSS. The generated text asking to manually update the labels in the Backport PR has been removed, so the code to fetch the PRs numbers is updated accordingly.

Also, the PR adds a task in the Pre-release checklist to create a new workflow for the stable branch to call the Backport Label Updater once a Backport PR is merged.

Depends on: https://github.com/cilium/cilium/pull/27875