### PR TITLE
Support v1 and v2 format when parsing Backport PRs

### DIFF
--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -93,13 +93,13 @@ func Test_getBackportPRs(t *testing.T) {
 	type args struct {
 		body string
 	}
-	tests := []struct {
+	testsV1 := []struct {
 		name string
 		args args
 		want []int
 	}{
 		{
-			name: "get all three PRs",
+			name: "get all three PRs in v1 block",
 			args: args{
 				body: "```upstream-prs\r\n$ for pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
@@ -110,7 +110,7 @@ func Test_getBackportPRs(t *testing.T) {
 			},
 		},
 		{
-			name: "get all three PRs (no prompt symbol)",
+			name: "get all three PRs in v1 block (no prompt symbol)",
 			args: args{
 				body: "```upstream-prs\r\nfor pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
@@ -121,7 +121,7 @@ func Test_getBackportPRs(t *testing.T) {
 			},
 		},
 		{
-			name: "get single PR",
+			name: "get single PR in v1 block",
 			args: args{
 				body: "```upstream-prs\r\n$ for pr in 9959 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
@@ -130,7 +130,7 @@ func Test_getBackportPRs(t *testing.T) {
 			},
 		},
 		{
-			name: "get single PR (no prompt symbol)",
+			name: "get single PR in v1 block (no prompt symbol)",
 			args: args{
 				body: "```upstream-prs\r\n$ for pr in 9959 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
@@ -139,28 +139,28 @@ func Test_getBackportPRs(t *testing.T) {
 			},
 		},
 		{
-			name: "command line pattern missing",
+			name: "command line pattern missing in v1 block",
 			args: args{
 				body: "```upstream-prs\r\n$ 9 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
 			want: nil,
 		},
 		{
-			name: "command line pattern missing (no prompt symbol)",
+			name: "command line pattern missing in v1 block (no prompt symbol)",
 			args: args{
 				body: "```upstream-prs\r\n9 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
 			want: nil,
 		},
 		{
-			name: "command line pattern incomplete",
+			name: "command line pattern incomplete in v1 block",
 			args: args{
 				body: "```upstream-prs\r\npr in 99 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\n```",
 			},
 			want: nil,
 		},
 		{
-			name: "unfinished quote section",
+			name: "unfinished quote section in v1 block",
 			args: args{
 				body: "```upstream-prs\n$ for pr in 9959 ; do contrib/backporting/set-labels.py $pr done 1.6; done\r\nfoo\nbar",
 			},
@@ -168,8 +168,44 @@ func Test_getBackportPRs(t *testing.T) {
 				9959,
 			},
 		},
+		{
+			name: "get all three PRs in v2 block",
+			args: args{
+				body: "```upstream-prs\r\n 9959 9982 10005\r\n```",
+			},
+			want: []int{
+				9959,
+				9982,
+				10005,
+			},
+		},
+		{
+			name: "get single PR in v2 block",
+			args: args{
+				body: "```upstream-prs\r\n 9959\r\n```",
+			},
+			want: []int{
+				9959,
+			},
+		},
+		{
+			name: "empty block in v2 block",
+			args: args{
+				body: "```upstream-prs\r\n\r\n```",
+			},
+			want: nil,
+		},
+		{
+			name: "unfinished quote section in v2 block",
+			args: args{
+				body: "```upstream-prs\n 9959\r\nfoo\nbar",
+			},
+			want: []int{
+				9959,
+			},
+		},
 	}
-	for _, tt := range tests {
+	for _, tt := range testsV1 {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getUpstreamPRs(tt.args.body); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getUpstreamPRs() = %v, want %v", got, tt.want)


### PR DESCRIPTION
The generated text asking to manually update the labels in the Backport
PRs has been removed and the getUpstreamPRs has been updated accordingly
in a previous commit.

Nevertheless, there will be a window where cilium/release will have to
parse Backport PRs with the "old" (v1) body format alongside Backport
PRs with the "new" (v2) body format.

An example of the v1 body format is this:

```
for pr in 9959 9982 10005; do contrib/backporting/set-labels.py $pr done 1.6; done
```

While the v2 body format is simply a space separated list of backported
PRs:

```
 9959 9982 10005
```

This commit extends the getUpstreamPRs function to look for text
patterns that should be present only in "v1" body format and then try to
parse the block using the parser for the guessed format.

The unit test has been updated to verify the function behaviour with PR
body written in both v1 and v2 formats.

Fixes: 88e810c ("pkg/github: Update code to fetch upstream PRs")