### PR TITLE
cmd: Fix checklist output

### DIFF
--- a/cmd/checklist/open.go
+++ b/cmd/checklist/open.go
@@ -84,7 +84,7 @@ func CreateIssue(ctx context.Context, ghClient *gh.Client, cfg ChecklistConfig, 
 		return fmt.Errorf("Failed to create release checklist: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Created issue at %s", *res.URL)
+	fmt.Fprintf(os.Stderr, "Created issue at %s\n", *res.HTMLURL)
 
 	return nil
 }


### PR DESCRIPTION
This output line was printing the wrong link, and missing a newline
afterwards. Fix it so that it provides a human-readable link to follow.