### PR TITLE
Update release process for new Helm chart tool

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -67,11 +67,8 @@ assignees: ''
   - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
         wait for the automatic checks to complete. Merge the PR.
 - [ ] Update helm charts
-  - [ ] Pull latest branch locally into the cilium repository.
   - [ ] Create helm charts artifacts in [Cilium charts] repository using
-        [cilium helm release tool] for the `vX.Y.0` release. Make sure the
-        generated helm charts point to the commit that contains the image
-        digests.
+        [cilium helm release tool] for the `vX.Y.0` release.
   - [ ] Check the output of the [chart workflow] and see if the test was
         successful.
 - [ ] Check [read the docs] configuration:
@@ -117,7 +114,7 @@ assignees: ''
 [releases]: https://github.com/cilium/cilium/releases
 [kops]: https://github.com/kubernetes/kops/
 [kubespray]: https://github.com/kubernetes-sigs/kubespray/
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -84,12 +84,10 @@ assignees: ''
   - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
         wait for the automatic checks to complete. Merge the PR.
 - [ ] Update helm charts
-  - [ ] Pull latest branch locally into the cilium repository.
   - [ ] Create helm charts artifacts in [Cilium charts] repository using
         [cilium helm release tool] for the `vX.Y.Z` release
-        and create a PR with these changes against the charts repository. Make
-        sure the generated helm charts point to the commit that contains the
-        image digests. Note: If you handle several patch releases at once,
+        and create a PR with these changes against the charts repository.
+        Note: If you handle several patch releases at once,
         create one PR per release, to make sure that the corresponding workflow
         action run for each commit. Wait for your PR to be merged before
         creating the other ones for other patch releases, or they will
@@ -121,6 +119,6 @@ assignees: ''
 [Cilium release-notes tool]: https://github.com/cilium/release
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -125,11 +125,9 @@ assignees: ''
   - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
         wait for the automatic checks to complete. Merge the PR.
 - [ ] Update helm charts
-  - [ ] Pull latest branch locally into the cilium repository.
   - [ ] Create helm charts artifacts in [Cilium charts] repository using
         [cilium helm release tool] for the `vX.Y.Z-rc.W` release and push these
-        changes into the helm repository. Make sure the generated helm charts
-        point to the commit that contains the image digests.
+        changes into the helm repository.
   - [ ] Check the output of the [chart workflow] and see if the test was
         successful.
 - [ ] Check [read the docs] configuration:
@@ -169,7 +167,7 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2FX.Y
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=vX.Y.Z-rc.W

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -57,8 +57,7 @@ assignees: ''
 - [ ] Update helm charts
   - [ ] Create helm charts artifacts in [Cilium charts] repository using
         [cilium helm release tool] for the `vX.Y.Z-rc.W` release and push
-        these changes into the helm repository. Make sure the generated helm
-        charts point to the commit that was tagged.
+        these changes into the helm repository.
   - [ ] Check the output of the [chart workflow] and see if the test was
         successful.
 - [ ] Check [read the docs] configuration:
@@ -96,7 +95,7 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 [Cilium charts]: https://github.com/cilium/charts
 [Cilium Image Release builds]: https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22
 [releases]: https://github.com/cilium/cilium/releases
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=vX.Y.Z-rc.W


### PR DESCRIPTION
We no longer need to pull the charts, because the new tool pulls the
charts directly from the Cilium tree.

See also https://github.com/cilium/charts/pull/114
