### PR TITLE
Update links in cilium/charts repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -114,7 +114,7 @@ assignees: ''
 [releases]: https://github.com/cilium/cilium/releases
 [kops]: https://github.com/kubernetes/kops/
 [kubespray]: https://github.com/kubernetes-sigs/kubespray/
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/
@@ -124,4 +124,4 @@ assignees: ''
 [network policy]: https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/
 [cluster administration networking]: https://kubernetes.io/docs/concepts/cluster-administration/networking/
 [cluster administration addons]: https://kubernetes.io/docs/concepts/cluster-administration/addons/
-[chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -112,6 +112,6 @@ assignees: ''
 [Cilium release-notes tool]: https://github.com/cilium/release
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
-[chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -167,9 +167,9 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2FX.Y
 [Cilium charts]: https://github.com/cilium/charts
 [releases]: https://github.com/cilium/cilium/releases
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=vX.Y.Z-rc.W
 [docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
-[chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -95,9 +95,9 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 [Cilium charts]: https://github.com/cilium/charts
 [Cilium Image Release builds]: https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22
 [releases]: https://github.com/cilium/cilium/releases
-[cilium helm release tool]: https://github.com/cilium/charts/blob/master/generate_helm_release.sh
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=vX.Y.Z-rc.W
 [docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
-[chart workflow]: https://github.com/cilium/charts/actions/workflows/conformance-gke.yaml
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml


### PR DESCRIPTION
- Point to RELEASE.md instead of generate_helm_release.sh. RELEASE.md contains instructions for using the script.
- conformance-gke.yaml has been replaced by validate-cilium-chart.yaml.

Ref: https://github.com/cilium/charts/pull/114
Ref: https://github.com/cilium/charts/pull/125