### PR TITLE
Add scripts to perform Cilium releases, with Git history included

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -38,7 +38,7 @@ assignees: ''
   - [ ] Pull latest changes from the branch being released
   - [ ] The next step will generate a `CHANGELOG.md` that will not be correct.
         That is expected, and it is fixed with a follow-up step. Don't worry.
-  - [ ] Run `contrib/release/start-release.sh X.Y.0 <GH-PROJECT> X.Y-1`
+  - [ ] Run `../release/internal/start-release.sh X.Y.0 <GH-PROJECT> X.Y-1`
         Note that this script produces some files at the root of the Cilium
         repository, and that these files are required at a later step for
         tagging the release.
@@ -49,11 +49,11 @@ assignees: ''
   - [ ] Add the 'stable' tag as part of the GitHub workflow and remove the
         'stable' tag from the last stable branch.
   - [ ] Commit all changes with title `Prepare for release vX.Y.0`
-  - [ ] Submit PR (`contrib/release/submit-release.sh`)
+  - [ ] Submit PR (`../release/internal/submit-release.sh`)
   - [ ] Submit a PR that removes the 'stable' tag from the last stable branch.
 - [ ] Merge PR
 - [ ] Create and push *both* tags to GitHub (`vX.Y.0`, `X.Y.0`)
-  - [ ] Pull latest branch locally and run `contrib/release/tag-release.sh`.
+  - [ ] Pull latest branch locally and run `../release/internal/tag-release.sh`.
 - [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
       [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
@@ -61,7 +61,7 @@ assignees: ''
         `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+  - [ ] Run `../release/internal/post-release.sh URL` to fetch the image
         digests and submit a PR to update these, use the `URL` of the GitHub
         run here
   - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
@@ -86,7 +86,7 @@ assignees: ''
 
 - [ ] Update the upgrade guide and [roadmap](https://github.com/cilium/cilium/blob/main/Documentation/community/roadmap.rst) for any features that changed status.
 - [ ] For new minor version update [security policy]
-- [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`
   - [ ] Make sure to update the `.github/maintainers-little-helper.yaml` so that
         upcoming PRs are tracked correctly for the next release.
   - [ ] Bump the main testsuite to upgrade from vX.Y branch to main

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -44,7 +44,7 @@ assignees: ''
 - [ ] Push a PR to cilium/cilium including the changes necessary for the new release:
   - [ ] Change directory to the local copy of cilium/cilium repository and pull latest
         changes from the branch being released
-  - [ ] Run `contrib/release/start-release.sh X.Y.Z N`, where `N` is the id of
+  - [ ] Run `../release/internal/start-release.sh X.Y.Z N`, where `N` is the id of
         the GitHub project created at the previous step. You can ignore
         warnings about commits with no related PR found.
         Note that this script produces some files at the root of the Cilium
@@ -54,7 +54,7 @@ assignees: ''
         generated files, such as release-state.json and vX.Y.Z-changes.txt
         should not be committed. Tip: use `git add -p` to review the changes and
         compare them with the previous release PR.
-  - [ ] Submit PR (`contrib/release/submit-release.sh`). Note that only the smoke tests
+  - [ ] Submit PR (`../release/internal/submit-release.sh`). Note that only the smoke tests
         need to succeed in order to merge this PR. Full e2e test runs are not required.
 - [ ] Merge PR
 - [ ] Ask a maintainer if there are any known issues that should hold up the release
@@ -63,7 +63,7 @@ assignees: ''
       the helm chart, users will face issues while trying out our documentation.
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
   - [ ] Pull latest `upstream/vX.Y` branch locally
-  - [ ] Run `contrib/release/tag-release.sh`.
+  - [ ] Run `../release/internal/tag-release.sh`.
 - [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
       [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
@@ -71,7 +71,7 @@ assignees: ''
         `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+  - [ ] Run `../release/internal/post-release.sh URL` to fetch the image
         digests and submit a PR to update these, use the `URL` of the GitHub
         run here
   - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
@@ -103,7 +103,7 @@ assignees: ''
 
 ## Post-release
 
-- [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`.
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`.
 
 [GitHub PAT tracker]: https://github.com/orgs/community/discussions/36441
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -94,7 +94,7 @@ assignees: ''
       - `git commit -sam "Prepare vX.Y stable branch"`
       - `gh pr create -B vX.Y`
 - [ ] Push a PR including the changes necessary for the new release:
-  - [ ] Run `./contrib/release/start-release.sh vX.Y.Z-rc.W`
+  - [ ] Run `../release/internal/start-release.sh vX.Y.Z-rc.W`
         Note that this script produces some files at the root of the Cilium
         repository, and that these files are required at a later step for
         tagging the release.
@@ -105,12 +105,12 @@ assignees: ''
         get the real names instead of GitHub usernames.
   - [ ] Add the generated `CHANGELOG.md` file and commit all remaining changes
         with the title `Prepare for release vX.Y.Z-rc.W`
-  - [ ] Submit PR (`contrib/release/submit-release.sh`)
+  - [ ] Submit PR (`../release/internal/submit-release.sh`)
 - [ ] Merge PR
 - [ ] Ping current top-hat that PRs can be merged again.
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z-rc.W`, `X.Y.Z-rc.W`)
   - Pull latest branch locally.
-  - Check out the release commit and run `contrib/release/tag-release.sh`
+  - Check out the release commit and run `../release/internal/tag-release.sh`
     against that commit.
 - [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
@@ -119,7 +119,7 @@ assignees: ''
         `make -C install/kubernetes/ RELEASE=yes CILIUM_BRANCH=vX.Y check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+  - [ ] Run `../release/internal/post-release.sh URL` to fetch the image
         digests and submit a PR to update these, use the `URL` of the GitHub
         run here
   - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
@@ -159,7 +159,7 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 ```
 - [ ] Bump the development snapshot version in `README.rst` on the main branch
       to point to this release
-- [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`.
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`.
 - [ ] Update the upgrade guide and [roadmap](https://github.com/cilium/cilium/blob/main/Documentation/community/roadmap.rst) for any features that changed status.
 
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags

--- a/.github/ISSUE_TEMPLATE/release_template_rc_master.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_master.md
@@ -24,7 +24,7 @@ assignees: ''
 - [ ] Change directory to the local copy of Cilium repository.
 - [ ] Check that there are no [release blockers] for the targeted release version
 - [ ] Push a PR including the changes necessary for the new release:
-  - [ ] Run `./contrib/release/start-release.sh vX.Y.Z-rc.W`
+  - [ ] Run `../release/internal/start-release.sh vX.Y.Z-rc.W`
         Note that this script produces some files at the root of the Cilium
         repository, and that these files are required at a later step for
         tagging the release.
@@ -34,7 +34,7 @@ assignees: ''
         previous step with title `update AUTHORS and Documentation`.
   - [ ] Add the generated `CHANGELOG.md` file and commit all remaining changes
         with the title `Prepare for release vX.Y.Z-rc.W`
-  - [ ] Submit PR (`contrib/release/submit-release.sh`)
+  - [ ] Submit PR (`../release/internal/submit-release.sh`)
   - [ ] Allow the CI to sanity-check the PR (GitHub actions are enough) and get
         review.
         Note that it's likely that the "helm-charts" will fail since the GH 
@@ -45,13 +45,13 @@ assignees: ''
 - [ ] Ping current top-hat that PRs can be merged again.
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z-rc.W`, `X.Y.Z-rc.W`)
   - Pull latest branch locally.
-  - Check out the commit before the revert and run `contrib/release/tag-release.sh`
+  - Check out the commit before the revert and run `../release/internal/tag-release.sh`
     against that commit.
 - [ ] Ask a maintainer to approve the build in the following link:
       [Cilium Image Release builds]
   - [ ] Check if all docker images are available before announcing the release:
         `make -C install/kubernetes/ RELEASE=yes CILIUM_BRANCH=main check-docker-images`
-  - [ ] Run `contrib/release/post-release.sh URL` to fetch the image
+  - [ ] Run `../release/internal/post-release.sh URL` to fetch the image
         digests and submit draft release to the [releases] page. Use the `URL`
         of the GitHub run here.
 - [ ] Update helm charts
@@ -88,7 +88,7 @@ https://github.com/cilium/cilium/releases/tag/vX.Y.Z-rc.W
 
 Thank you for the testing and contributing to the previous pre-releases. There are [vX.Y.Z-rc.W OSS docs](https://docs.cilium.io/en/vX.Y.Z-rc.W) available if you want to pull this version & try it out.
 ```
-- [ ] Prepare post-release changes to main branch using `contrib/release/bump-readme.sh`.
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`.
 
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -14,7 +14,7 @@ ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 latest_stable=""
-for release in $(grep "General Announcement" README.rst \
+for release in $(grep "Release Notes" README.rst \
                  | sed 's/.*tree\/\(v'"$MAJ_REGEX"'\).*/\1/'); do
     latest=$(git describe --tags $REMOTE/$release \
              | sed 's/v//' | sed 's/\('"$MIN_REGEX"'\).*/\1/')

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -112,7 +112,7 @@ check_table "commits/v1"
 
 git add README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML
 if ! git diff-index --quiet HEAD -- README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML; then
-    git commit -s -m "Update stable releases"
+    git commit -s -m "README: Update releases"
     echo "README.rst and stable.txt updated, submit the PR now."
 else
     echo "No new releases found."

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -29,7 +29,7 @@ for release in $(grep "Release Notes" README.rst \
     fi
 
     current=$(grep -F $release README.rst \
-              | sed 's/.*\('"$MIN_REGEX"'\).*/\1/')
+              | sed 's/.*\('"$MIN_REGEX"'\).*/\1/' | head -n 1)
     old_date=$(git log -1 -s --format="%cI" $current | sed "$REGEX_FILTER_DATE")
     new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
     elease=$(echo $release | sed 's/v//')

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -6,6 +6,9 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
+set -e
+set -o pipefail
+
 MAJ_REGEX='[0-9]\+\.[0-9]\+'
 VER_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(pre\|rc\)\.[0-9]\+\)\?'
 PRE_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+-\(pre\|rc\)\.[0-9]\+'

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -7,17 +7,51 @@ source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
 MAJ_REGEX='[0-9]\+\.[0-9]\+'
-MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
+VER_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(pre\|rc\)\.[0-9]\+\)\?'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 latest_stable=""
+
+# $1 - release branch
+# $2 - latest release for the target branch (maybe vX.Y+1* for prerelease)
+# #3 - git tree path to commit object, eg tree/ or commits/
+# $4 - regex to strip out constant release info from a release line
+update_release() {
+    old_branch="$1"
+    latest="$2"
+    obj_regex="$3"
+    rem_branch_regex="$4"
+
+    new_branch=$(echo $latest | sed 's/\('$MAJ_REGEX'\).*/v\1/')
+    current=$(grep "$obj_regex$old_branch" README.rst \
+              | sed 's/^.*'"$obj_regex"'.*tag\/v\('"$rem_branch_regex"'\).*$/\1/')
+    old_date=$(git log -1 -s --format="%cI" v$current | sed "$REGEX_FILTER_DATE")
+    new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
+    elease=$(echo $old_branch | sed 's/v//')
+    old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
+               | sed "$PROJECTS_REGEX")
+    new_proj=$(git show $REMOTE/$old_branch:$ACTS_YAML | grep projects \
+               | sed "$PROJECTS_REGEX")
+
+    printf "%10s %10s %10s %10s\n" "current" "old_date" "new_date" "elease"
+    printf "%10s %10s %10s %10s\n" $current  $old_date  $new_date  $elease
+
+    echo "Updating $old_branch:"
+    echo "  $current on $old_date with project $old_proj to"
+    echo "  $latest on $new_date with project $new_proj"
+    sed -i '/'$obj_regex'/s/'$old_branch'\(.*\)'$old_date'/'$new_branch'\1'$new_date'/g' README.rst
+    sed -i '/'$obj_regex'/s/v'$current'/v'$latest'/g' README.rst
+    sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
+
+}
+
 for release in $(grep "Release Notes" README.rst \
                  | sed 's/.*tree\/\(v'"$MAJ_REGEX"'\).*/\1/'); do
     latest=$(git describe --tags $REMOTE/$release \
-             | sed 's/v//' | sed 's/\('"$MIN_REGEX"'\).*/\1/')
+             | sed 's/v//' | sed 's/\('"$VER_REGEX"'\).*/\1/')
     if [ -z "$latest_stable" ]; then
         # the first release in the list is the latest stable
         latest_stable=$latest
@@ -28,22 +62,7 @@ for release in $(grep "Release Notes" README.rst \
         continue
     fi
 
-    current=$(grep -F $release README.rst \
-              | sed 's/.*\('"$MIN_REGEX"'\).*/\1/' | head -n 1)
-    old_date=$(git log -1 -s --format="%cI" $current | sed "$REGEX_FILTER_DATE")
-    new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
-    elease=$(echo $release | sed 's/v//')
-    old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
-               | sed "$PROJECTS_REGEX")
-    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep projects \
-               | sed "$PROJECTS_REGEX")
-
-    echo "Updating $release:"
-    echo "  $current on $old_date with project $old_proj to"
-    echo "  $latest on $new_date with project $new_proj"
-    sed -i 's/\('$release'.*\)'$old_date'/\1'$new_date'/g' README.rst
-    sed -i 's/v'$current'/v'$latest'/g' README.rst
-    sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
+    update_release $release $latest "tree\/" "$VER_REGEX"
 done
 
 git add README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -10,7 +10,7 @@ MAJ_REGEX='[0-9]\+\.[0-9]\+'
 MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 latest_stable=""

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -8,6 +8,7 @@ source $DIR/lib/common.sh
 
 MAJ_REGEX='[0-9]\+\.[0-9]\+'
 VER_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(pre\|rc\)\.[0-9]\+\)\?'
+PRE_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+-\(pre\|rc\)\.[0-9]\+'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
@@ -31,10 +32,15 @@ update_release() {
     old_date=$(git log -1 -s --format="%cI" v$current | sed "$REGEX_FILTER_DATE")
     new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
     elease=$(echo $old_branch | sed 's/v//')
-    old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
-               | sed "$PROJECTS_REGEX")
-    new_proj=$(git show $REMOTE/$old_branch:$ACTS_YAML | grep projects \
-               | sed "$PROJECTS_REGEX")
+
+    old_proj=""
+    new_proj=""
+    if grep -qF "$elease" $ACTS_YAML; then
+        old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
+                   | sed "$PROJECTS_REGEX")
+        new_proj=$(git show $REMOTE/$old_branch:$ACTS_YAML | grep projects \
+                   | sed "$PROJECTS_REGEX")
+    fi
 
     printf "%10s %10s %10s %10s\n" "current" "old_date" "new_date" "elease"
     printf "%10s %10s %10s %10s\n" $current  $old_date  $new_date  $elease
@@ -44,8 +50,9 @@ update_release() {
     echo "  $latest on $new_date with project $new_proj"
     sed -i '/'$obj_regex'/s/'$old_branch'\(.*\)'$old_date'/'$new_branch'\1'$new_date'/g' README.rst
     sed -i '/'$obj_regex'/s/v'$current'/v'$latest'/g' README.rst
-    sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
-
+    if [ -n $old_proj ]; then
+        sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
+    fi
 }
 
 for release in $(grep "Release Notes" README.rst \
@@ -63,6 +70,17 @@ for release in $(grep "Release Notes" README.rst \
     fi
 
     update_release $release $latest "tree\/" "$VER_REGEX"
+done
+
+for release in $(grep "$PRE_REGEX" README.rst \
+                 | sed 's/.*commits\/\(v'"$MAJ_REGEX"'\).*/\1/'); do
+    latest=$(git describe --tags $REMOTE/main \
+             | sed 's/v//' | sed 's/\('"$PRE_REGEX"'\).*/\1/')
+    if grep -q -F $latest README.rst; then
+        continue
+    fi
+
+    update_release $release $latest "commits\/" "$PRE_REGEX"
 done
 
 git add README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -41,7 +41,7 @@ for release in $(grep "General Announcement" README.rst \
     echo "  $current on $old_date with project $old_proj to"
     echo "  $latest on $new_date with project $new_proj"
     sed -i 's/\('$release'.*\)'$old_date'/\1'$new_date'/g' README.rst
-    sed -i 's/'$current'/'$latest'/g' README.rst
+    sed -i 's/v'$current'/v'$latest'/g' README.rst
     sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
 done
 

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -22,6 +22,7 @@ for release in $(grep "General Announcement" README.rst \
         # the first release in the list is the latest stable
         latest_stable=$latest
         echo "v$latest_stable" > stable.txt
+        echo '{"results":[{"slug":"v'"$(echo "${latest_stable}" | grep -Eo '[0-9]+\.[0-9]+')"'"}]}' > Documentation/_static/stable-version.json
     fi
     if grep -q -F $latest README.rst; then
         continue
@@ -45,8 +46,8 @@ for release in $(grep "General Announcement" README.rst \
     sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
 done
 
-git add README.rst stable.txt $ACTS_YAML
-if ! git diff-index --quiet HEAD -- README.rst stable.txt $ACTS_YAML; then
+git add README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML
+if ! git diff-index --quiet HEAD -- README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML; then
     git commit -s -m "Update stable releases"
     echo "README.rst and stable.txt updated, submit the PR now."
 else

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh

--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -34,7 +34,7 @@ for release in $(grep "General Announcement" README.rst \
     elease=$(echo $release | sed 's/v//')
     old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
                | sed "$PROJECTS_REGEX")
-    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep project \
+    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep projects \
                | sed "$PROJECTS_REGEX")
 
     echo "Updating $release:"

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -77,7 +77,7 @@ get_branch_from_version() {
     local remote="$1"
     local branch="$(echo $2 | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
     if [ -z "$(git ls-remote --heads $remote $branch)" ]; then
-        branch="master"
+        branch="main"
     fi
     echo "$branch"
 }

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -50,3 +50,11 @@ require_linux() {
       exit 1
   fi
 }
+
+commit_in_upstream() {
+    local commit="$1"
+    local branch="$2"
+    local remote="$(get_remote)"
+    local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
+    echo "$branches" | grep -q ".*$remote/$branch"
+}

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -82,3 +82,15 @@ get_branch_from_version() {
     fi
     echo "$branch"
 }
+
+# $1 - VERSION
+version_is_prerelease() {
+    case "$1" in
+        *pre*|*rc*|*snapshot*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -22,7 +22,7 @@ get_remote () {
 }
 
 get_user() {
-  gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+  gh_username=$(gh api user | jq -r '.login')
   if [ "$gh_username" = "" ]; then
     echo "Error: could not get user info from hub" 1>&2
     exit 1
@@ -50,7 +50,7 @@ is_collaborator() {
       exit 1
   fi
   local path="repos/$org/$repo/collaborators/$username"
-  if hub api "$path" &> /dev/null; then
+  if gh api "$path" &> /dev/null; then
     echo "yes"
   else
     echo "no"

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -12,7 +12,7 @@ get_remote () {
   local org=${1:-cilium}
   local repo=${2:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]${org}/${repo}" | \
+    grep "github.com[/:]${org}/${repo} " | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
       echo "No remote git@github.com:${org}/${repo}.git or https://github.com/${org}/${repo} found" 1>&2

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
-#
+# SPDX-License-Identifier: Apache-2.0
 # Copyright 2019-2021 Authors of Cilium
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 set -e
 

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -94,3 +94,15 @@ version_is_prerelease() {
             ;;
     esac
 }
+
+# $1 - VERSION
+version_is_rc() {
+    case "$1" in
+        *rc*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -32,15 +32,20 @@ get_remote () {
   echo "$remote"
 }
 
+get_user() {
+  gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+  if [ "$gh_username" = "" ]; then
+    echo "Error: could not get user info from hub" 1>&2
+    exit 1
+  fi
+  echo $gh_username
+}
+
 # $1 - override
 get_user_remote() {
   USER_REMOTE=${1:-}
   if [ "$USER_REMOTE" = "" ]; then
-      gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
-      if [ "$gh_username" = "" ]; then
-          echo "Error: could not get user info from hub" 1>&2
-          exit 1
-      fi
+      gh_username=$(get_user)
       USER_REMOTE=$(get_remote "$gh_username")
       echo "Using GitHub repository ${gh_username}/cilium (git remote: ${USER_REMOTE})" 1>&2
   fi

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -40,6 +40,22 @@ get_user_remote() {
   echo $USER_REMOTE
 }
 
+is_collaborator() {
+  local username=${1:-}
+  local org=${2:-cilium}
+  local repo=${3:-cilium}
+  if [ -z "$username" ]; then
+      echo "Error: no username specified in is_collaborator"
+      exit 1
+  fi
+  local path="repos/$org/$repo/collaborators/$username"
+  if hub api "$path" &> /dev/null; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
 require_linux() {
   if [ "$(uname)" != "Linux" ]; then
       echo "$0: Linux required"

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -4,7 +4,8 @@
 
 set -e
 
-RELEASE_REGEX="[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"
+RELEASE_REGEX="[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(pre\)\)\(\.\)\?[0-9]\+\)\?$"
+RELEASE_FORMAT_MSG="Expected X.Y.Z-[rc.N|pre.N]"
 
 get_remote () {
   local remote

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -16,6 +16,8 @@
 
 set -e
 
+RELEASE_REGEX="[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"
+
 get_remote () {
   local remote
   local org=${1:-cilium}
@@ -60,4 +62,13 @@ commit_in_upstream() {
     local remote="$(get_remote ${org} ${repo})"
     local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
     echo "$branches" | grep -q ".*$remote/$branch"
+}
+
+get_branch_from_version() {
+    local remote="$1"
+    local branch="$(echo $2 | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
+    if [ -z "$(git ls-remote --heads $remote $branch)" ]; then
+        branch="master"
+    fi
+    echo "$branch"
 }

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -12,7 +12,7 @@ get_remote () {
   local org=${1:-cilium}
   local repo=${2:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]${org}/${repo} " | \
+    grep "github.com[/:]${org}/${repo}\(\.git\)\? " | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
       echo "No remote git@github.com:${org}/${repo}.git or https://github.com/${org}/${repo} found" 1>&2

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -19,11 +19,12 @@ set -e
 get_remote () {
   local remote
   local org=${1:-cilium}
+  local repo=${2:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]${org}/cilium" | \
+    grep "github.com[/:]${org}/${repo}" | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
-      echo "No remote git@github.com:${org}/cilium.git or https://github.com/${org}/cilium found" 1>&2
+      echo "No remote git@github.com:${org}/${repo}.git or https://github.com/${org}/${repo} found" 1>&2
       return 1
   fi
   echo "$remote"
@@ -54,7 +55,9 @@ require_linux() {
 commit_in_upstream() {
     local commit="$1"
     local branch="$2"
-    local remote="$(get_remote)"
+    local org="${3:-"cilium"}"
+    local repo="${4:-"cilium"}"
+    local remote="$(get_remote ${org} ${repo})"
     local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
     echo "$branches" | grep -q ".*$remote/$branch"
 }

--- a/internal/lib/common.sh
+++ b/internal/lib/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2019-2021 Authors of Cilium
+# Copyright Authors of Cilium
 
 set -e
 

--- a/internal/lib/gitlib.sh
+++ b/internal/lib/gitlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/internal/lib/gitlib.sh
+++ b/internal/lib/gitlib.sh
@@ -35,7 +35,7 @@ CILIUM_GITHUB_SSH='git@github.com:cilium/cilium.git'
 # 2=Minor
 # 3=.Patch
 # 4=Patch
-BRANCH_REGEX="master|release-([0-9]{1,})\.([0-9]{1,})(\.([0-9]{1,}))*$"
+BRANCH_REGEX="main|release-([0-9]{1,})\.([0-9]{1,})(\.([0-9]{1,}))*$"
 # release - 1=Major, 2=Minor, 3=Patch, 4=-(alpha|beta|rc), 5=rev
 # dotzero - 1=Major, 2=Minor
 # build - 1=build number, 2=sha1

--- a/internal/lib/gitlib.sh
+++ b/internal/lib/gitlib.sh
@@ -20,7 +20,7 @@
 ###############################################################################
 # CONSTANTS
 ###############################################################################
-GHCURL="curl -s --fail --retry 10 -u ${GITHUB_TOKEN:-$FLAGS_github_token}:x-oauth-basic"
+GHCURL="curl -s --fail --retry 10 -u x-access-token:${GITHUB_TOKEN:-$FLAGS_github_token}"
 JCURL="curl -g -s --fail --retry 10"
 CILIUM_GITHUB_API='https://api.github.com/repos/cilium/cilium'
 CILIUM_GITHUB_RAW_ORG='https://raw.githubusercontent.com/cilium'

--- a/internal/lib/k8s-common.sh
+++ b/internal/lib/k8s-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -23,7 +23,7 @@ handle_args() {
         common::exit 1
     fi
 
-    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]] || [[ $# -lt 1 ]]; then
         usage
         common::exit 0
     fi
@@ -36,6 +36,11 @@ handle_args() {
 
     if ! git diff --quiet; then
         echo "Local changes found in git tree. Exiting release process..." 1>&2
+        exit 1
+    fi
+
+    if ! echo "$1" | grep -q ".*github.com.*actions.*"; then
+        echo "Invalid URL. The URL must be the overall actions page, not one specific run." 1>&2
         exit 1
     fi
 
@@ -64,7 +69,7 @@ main() {
     logecho "Check that the following changes look correct:"
     # TODO: Make this less interactive when we have used it enough
     git add --patch install/kubernetes
-    git commit -se -m "install: Update image digests for $version" -m "$(cat digest-$version.txt)"
+    git commit -se -m "install: Update image digests for $version" -m "Generated from $1." -m "$(cat digest-$version.txt)"
     echo "Create PR for v$branch with these changes"
     if ! common::askyorn ; then
         common::exit 0 "Aborting post-release updates."

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source "${DIR}/lib/k8s-common.sh"
+source "${DIR}/lib/common.sh"
+
+usage() {
+    logecho "usage: $0 <RUN-URL> [VERSION] [GH-USERNAME]"
+    logecho "RUN-URL      GitHub URL with the RUN for the release images"
+    logecho "             example: https://github.com/cilium/cilium/actions/runs/600920964"
+    logecho "VERSION      Target version (X.Y.Z) (default: read from VERSION file)"
+    logecho "GH-USERNAME  GitHub username for authentication (default: autodetect)"
+    logecho "GITHUB_TOKEN environment variable set with the scope public:repo"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 4; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! hub help | grep -q "pull-request"; then
+        echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+        echo "Please install this tool first." 1>&2
+        common::exit 1
+    fi
+
+    if ! git diff --quiet; then
+        echo "Local changes found in git tree. Exiting release process..." 1>&2
+        exit 1
+    fi
+
+    if [ ! -z "$2" ] && ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$2\"; Expected X.Y.Z"
+    fi
+
+    if [ -z "${GITHUB_TOKEN}" ]; then
+        usage 2>&1
+        common::exit 1 "GITHUB_TOKEN not set!"
+    fi
+}
+
+main() {
+    handle_args "$@"
+    local ersion version branch user_remote
+    ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
+    version="v${ersion}"
+    branch=$(echo $version | sed 's/.*v\([0-9]\.[0-9]\).*/\1/')
+    user_remote=$(get_user_remote ${3:-})
+
+    git checkout -b pr/$version-digests $version
+    ${DIR}/pull-docker-manifests.sh "$@"
+    logecho
+    logecho "Check that the following changes look correct:"
+    # TODO: Make this less interactive when we have used it enough
+    git add --patch install/kubernetes
+    git commit -se -m "install: Update image digests for $version" -m "$(cat digest-$version.txt)"
+    echo "Create PR for v$branch with these changes"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting post-release updates."
+    fi
+    logecho "Sending pull request for branch v$branch..."
+    PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    git push $user_remote "$PR_BRANCH"
+    hub pull-request -b "v$branch" -l backport/$branch
+}
+
+main "$@"

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -6,6 +6,8 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/k8s-common.sh"
 source "${DIR}/lib/common.sh"
 
+RELEASES_URL="https://github.com/cilium/cilium/releases"
+
 usage() {
     logecho "usage: $0 <RUN-URL> [VERSION] [GH-USERNAME]"
     logecho "RUN-URL      GitHub URL with the RUN for the release images"

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -71,6 +71,10 @@ main() {
     tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' > $version-release-summary.txt
     tail -n+2 digest-$version.txt >> $version-release-summary.txt
     logecho "Creating Github draft release"
+    prerelease=""
+    if echo $ersion | grep -q 'pre\|rc'; then
+        prerelease="-p"
+    fi
     logrun gh release create -d $prerelease -F $version-release-summary.txt $version --title "$ersion"
     logecho "Browse to $RELEASES_URL to see the draft release"
 

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -28,8 +28,8 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! hub help | grep -q "pull-request"; then
-        echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    if ! gh help > /dev/null; then
+        echo "This tool relies on 'gh' from https://cli.github.com/." 1>&2
         echo "Please install this tool first." 1>&2
         common::exit 1
     fi
@@ -66,13 +66,12 @@ main() {
     git checkout -b pr/$version-digests $version
     ${DIR}/pull-docker-manifests.sh "$@"
 
-    echo -e "$ersion\n" > $version-release-summary.txt
     # Grab the release notes for the current release, stop before the next
     # release. The start of line `## vX.Y.Z` lines will match in command.
-    tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' >> $version-release-summary.txt
+    tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' > $version-release-summary.txt
     tail -n+2 digest-$version.txt >> $version-release-summary.txt
     logecho "Creating Github draft release"
-    logrun hub release create -d -F $version-release-summary.txt $version
+    logrun gh release create -d $prerelease -F $version-release-summary.txt $version --title "$ersion"
     logecho "Browse to $RELEASES_URL to see the draft release"
 
     if version_is_prerelease "$version" && ! version_is_rc "$version"; then
@@ -95,7 +94,7 @@ main() {
     logecho "Sending pull request for branch v$branch..."
     PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     git push $user_remote "$PR_BRANCH"
-    hub pull-request -b "v$branch" -l backport/$branch
+    gh pr create -B "v$branch" -l backport/$branch
 }
 
 main "$@"

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -55,7 +55,7 @@ main() {
     local ersion version branch user_remote
     ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
     version="v${ersion}"
-    branch=$(echo $version | sed 's/.*v\([0-9]\.[0-9]\).*/\1/')
+    branch=$(echo $version | sed 's/.*v\([0-9]\+\.[0-9]\+\).*/\1/')
     user_remote=$(get_user_remote ${3:-})
 
     git checkout -b pr/$version-digests $version

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -49,9 +49,8 @@ handle_args() {
         common::exit 1 "Invalid VERSION ARG \"$2\"; $RELEASE_FORMAT_MSG"
     fi
 
-    if [ -z "${GITHUB_TOKEN}" ]; then
-        usage 2>&1
-        common::exit 1 "GITHUB_TOKEN not set!"
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
     fi
 }
 

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -75,7 +75,7 @@ main() {
     logrun hub release create -d -F $version-release-summary.txt $version
     logecho "Browse to $RELEASES_URL to see the draft release"
 
-    if version_is_prerelease "$version"; then
+    if version_is_prerelease "$version" && ! version_is_rc "$version"; then
         # No digest updates for main branch for prereleases.
         return
     fi

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -65,7 +65,9 @@ main() {
 
     git checkout -b pr/$version-digests $version
     ${DIR}/pull-docker-manifests.sh "$@"
-    logrun make -C Documentation update-helm-values
+    if grep -q update-helm-values Documentation/Makefile; then
+        logrun make -C Documentation update-helm-values
+    fi
     logecho
     logecho "Check that the following changes look correct:"
     # TODO: Make this less interactive when we have used it enough

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2021 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/k8s-common.sh"

--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -65,10 +65,11 @@ main() {
 
     git checkout -b pr/$version-digests $version
     ${DIR}/pull-docker-manifests.sh "$@"
+    logrun make -C Documentation update-helm-values
     logecho
     logecho "Check that the following changes look correct:"
     # TODO: Make this less interactive when we have used it enough
-    git add --patch install/kubernetes
+    git add --patch install/kubernetes Documentation/
     git commit -se -m "install: Update image digests for $version" -m "Generated from $1." -m "$(cat digest-$version.txt)"
     echo "Create PR for v$branch with these changes"
     if ! common::askyorn ; then

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -33,12 +33,12 @@ handle_args() {
 
     if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
     fi
 
     if ! echo "$2" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; Expected X.Y.Z[-rcW]"
+        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
     fi
 
     if [ "$#" -eq 3 ] && ! echo "$3" | grep -q "[0-9]\+\.[0-9]\+"; then

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -33,12 +33,12 @@ handle_args() {
 
     if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; $RELEASE_FORMAT_MSG"
     fi
 
     if ! echo "$2" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
+        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; $RELEASE_FORMAT_MSG"
     fi
 
     if [ "$#" -eq 3 ] && ! echo "$3" | grep -q "[0-9]\+\.[0-9]\+"; then

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -58,6 +58,7 @@ main() {
     local ersion="$(echo $2 | sed 's/^v//')"
     local version="v$ersion"
     local old_branch="$(echo $3 | sed 's/^v//')"
+    local GITHUB_TOKEN=${GITHUB_TOKEN:-"$(gh auth token)"}
 
     logecho "Generating CHANGELOG.md"
     rm -f $RELNOTESCACHE

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -45,6 +45,10 @@ handle_args() {
         usage 2>&1
         common::exit 1 "Invalid OLD-BRANCH ARG \"$3\"; Expected X.Y"
     fi
+
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
+    fi
 }
 
 main() {

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -59,6 +59,7 @@ main() {
     local version="v$ersion"
     local old_branch="$(echo $3 | sed 's/^v//')"
     local GITHUB_TOKEN=${GITHUB_TOKEN:-"$(gh auth token)"}
+    export GITHUB_TOKEN
 
     logecho "Generating CHANGELOG.md"
     rm -f $RELNOTESCACHE

--- a/internal/prep-changelog.sh
+++ b/internal/prep-changelog.sh
@@ -29,12 +29,12 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+    if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z"
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
     fi
 
-    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+[-rc0-9]*"; then
+    if ! echo "$2" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
         common::exit 1 "Invalid NEW-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
     fi

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -4,17 +4,18 @@
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/k8s-common.sh"
+source "${DIR}/lib/common.sh"
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 
 repo="cilium/cilium"
 
 usage() {
-    logecho "usage: $0 <GH-USERNAME> <VERSION> <RUN-URL>"
-    logecho "GH-USERNAME  GitHub username"
-    logecho "VERSION      Target version (X.Y.Z)"
+    logecho "usage: $0 <RUN-URL> [VERSION] [GH-USERNAME]"
     logecho "RUN-URL      GitHub URL with the RUN for the release images"
     logecho "             example: https://github.com/cilium/cilium/actions/runs/600920964"
+    logecho "VERSION      Target version (X.Y.Z) (default: read from VERSION file)"
+    logecho "GH-USERNAME  GitHub username for authentication (default: autodetect)"
     logecho "GITHUB_TOKEN environment variable set with the scope public:repo"
     logecho
     logecho "--help     Print this help message"
@@ -64,10 +65,10 @@ get_digest_output() {
 main() {
     handle_args "$@"
     local username ersion version run_url_id
-    username="${1}"
-    ersion="$(echo ${2} | sed 's/^v//')"
+    run_url_id="$(basename "${1}")"
+    ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
     version="v${ersion}"
-    run_url_id="$(basename "${3}")"
+    username=$(get_user_remote ${3:-})
 
     if [ ! -e "${PWD}/install/kubernetes/Makefile.digests" ]; then
         >&2 echo "Cannot find install/kubernetes/Makefile.digests"

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -68,7 +68,6 @@ main() {
     run_url_id="$(basename "${1}")"
     ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
     version="v${ersion}"
-    branch=$(echo $version | sed 's/.*v\([0-9]\+\.[0-9]\+\).*/\1/')
     username=$(get_user_remote ${3:-})
     upstream_remote="$(get_remote)"
 
@@ -82,11 +81,7 @@ main() {
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
     cp "${makefile_digest}" "${PWD}/install/kubernetes/Makefile.digests"
-    CILIUM_BRANCH="main"
-    if git branch -a | grep -q "${upstream_remote}/v${branch}$"; then
-        CILIUM_BRANCH="v${branch}"
-    fi
-    make -C install/kubernetes/ CILIUM_BRANCH=${CILIUM_BRANCH} RELEASE=yes
+    make -C install/kubernetes/ RELEASE=yes
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright 2021 Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/k8s-common.sh"
@@ -32,7 +32,7 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+    if [ -n "$2" ] && ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
         usage 2>&1
         common::exit 1 "Invalid VERSION ARG \"$2\"; Expected X.Y.Z"
     fi
@@ -85,6 +85,7 @@ main() {
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""
     image_digest_output=$(get_digest_output "${username}" "${run_url_id}" "${version}" image-digest-output.txt)
+    echo > "${PWD}/digest-${version}.txt"
     cat "${image_digest_output}" >> "${PWD}/digest-${version}.txt"
     >&2 echo "Image digests available at ${PWD}/digest-${version}.txt"
 }

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -37,14 +37,14 @@ handle_args() {
         common::exit 1 "Invalid VERSION ARG \"$2\"; Expected X.Y.Z"
     fi
 
-    if [ -z "${GITHUB_TOKEN}" ]; then
-        usage 2>&1
-        common::exit 1 "GITHUB_TOKEN not set!"
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
     fi
 }
 
 get_digest_output() {
     local username run_id file tmp_dir archive_download_url archive_download_url_zip
+    local GITHUB_TOKEN=${GITHUB_TOKEN:-$(gh auth token)}
 
     username="${1}"
     run_id="${2}"

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2021 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/k8s-common.sh"

--- a/internal/pull-docker-manifests.sh
+++ b/internal/pull-docker-manifests.sh
@@ -68,7 +68,9 @@ main() {
     run_url_id="$(basename "${1}")"
     ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
     version="v${ersion}"
+    branch=$(echo $version | sed 's/.*v\([0-9]\+\.[0-9]\+\).*/\1/')
     username=$(get_user_remote ${3:-})
+    upstream_remote="$(get_remote)"
 
     if [ ! -e "${PWD}/install/kubernetes/Makefile.digests" ]; then
         >&2 echo "Cannot find install/kubernetes/Makefile.digests"
@@ -80,7 +82,11 @@ main() {
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
     cp "${makefile_digest}" "${PWD}/install/kubernetes/Makefile.digests"
-    make -C install/kubernetes/
+    CILIUM_BRANCH="main"
+    if git branch -a | grep -q "${upstream_remote}/v${branch}$"; then
+        CILIUM_BRANCH="v${branch}"
+    fi
+    make -C install/kubernetes/ CILIUM_BRANCH=${CILIUM_BRANCH} RELEASE=yes
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -81,7 +81,7 @@ main() {
     local old_version=""
 
     git fetch -q $REMOTE
-    if [ "$branch" = "master" ]; then
+    if [ "$branch" = "main" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
         if ! version_is_prerelease "$version"; then
             old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -109,6 +109,7 @@ main() {
     target_branch=$(echo "$version" | sed "$BRANCH_REGEX")
     if ! git ls-remote --exit-code --heads $REMOTE $target_branch; then
         target_branch=$(echo "$old_version" | sed "$BRANCH_REGEX")
+        old_branch="$target_branch"
     fi
     $DIR/../../Documentation/check-crd-compat-table.sh "$target_branch" --update
     if [ "${old_branch}" != "" ]; then

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -83,8 +83,8 @@ main() {
     git fetch -q $REMOTE
     if [ "$branch" = "master" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
-        if echo "$version" | grep -q 'rc'; then
-            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'snapshot' | sort -V | tail -n 1)"
+        if version_is_prerelease "$version"; then
+            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"
         else
             old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"
         fi
@@ -107,6 +107,9 @@ main() {
     fi
 
     target_branch=$(echo "$version" | sed "$BRANCH_REGEX")
+    if ! git ls-remote --exit-code --heads $REMOTE $target_branch; then
+        target_branch=$(echo "$old_version" | sed "$BRANCH_REGEX")
+    fi
     $DIR/../../Documentation/check-crd-compat-table.sh "$target_branch" --update
     if [ "${old_branch}" != "" ]; then
       $DIR/prep-changelog.sh "$old_version" "$version" "$old_branch"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -83,7 +83,7 @@ main() {
     git fetch -q $REMOTE
     if [ "$branch" = "master" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
-        if version_is_prerelease "$version"; then
+        if ! version_is_prerelease "$version"; then
             old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"
         else
             old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -97,6 +97,7 @@ main() {
         sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
     fi
 
+    $DIR/../../Documentation/check-crd-compat-table.sh "$branch"
     $DIR/prep-changelog.sh "$old_version" "$version"
 
     logecho "Next steps:"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -63,6 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
+    sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -22,18 +22,6 @@ usage() {
     logecho "--help     Print this help message"
 }
 
-# $1 - VERSION
-version_is_prerelease() {
-    case "$1" in
-        *pre*|*rc*|*snapshot*)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
 handle_args() {
     if [ "$#" -gt 3 ]; then
         usage 2>&1

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -113,12 +113,12 @@ main() {
     else
       $DIR/prep-changelog.sh "$old_version" "$version"
     fi
+    git commit -a -s -m "Prepare for release $version"
 
     logecho "Next steps:"
-    logecho "* Check all changes and add to a new commit"
+    logecho "* Check the new release commit with 'git show'"
     logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
-    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
 
     # Leave $version-changes.txt around for prep-release.sh usage later

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -7,6 +7,7 @@ source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+VERSION_TO_BRANCH_REGEX='s/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
@@ -16,6 +17,18 @@ usage() {
     logecho "GH-PROJECT Project Number for next (X.Y.Z+1) development release"
     logecho
     logecho "--help     Print this help message"
+}
+
+# $1 - VERSION
+version_is_prerelease() {
+    case "$1" in
+        *rc*|*snapshot*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 handle_args() {
@@ -29,12 +42,12 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"; then
         usage 2>&1
         common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
     fi
 
-    if ! echo "$2" | grep -q "^[0-9]\+"; then
+    if ! echo "$2" | grep -q "^[0-9]\+" && ! version_is_prerelease "$1"; then
         usage 2>&1
         common::exit 1 "Invalid GH-PROJECT ID argument. Expected [0-9]+"
     fi
@@ -54,25 +67,37 @@ main() {
 
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
-    local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local branch="v$(echo $ersion | sed $VERSION_TO_BRANCH_REGEX)"
     local new_proj="$2"
+    local old_version=""
 
     git fetch $REMOTE
-    git checkout -b pr/prepare-$version $REMOTE/$branch
-    local old_version="$(cat VERSION)"
+    if [ -n "$(git ls-remote --heads $REMOTE $branch)" ]; then
+        git checkout -b pr/prepare-$version $REMOTE/$branch
+        old_version="$(cat VERSION)"
+    else
+        logecho "Cannot find $REMOTE/$branch. Basing release on master."
+        branch="master"
+        git checkout -b pr/prepare-$version $REMOTE/$branch
+        local old_branch="$(cat VERSION | sed $VERSION_TO_BRANCH_REGEX)"
+        old_version="$(git show v$old_branch:VERSION)"
+    fi
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
-    old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
-    sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+    if ! version_is_prerelease "$version"; then
+        old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
+        sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+    fi
 
     $DIR/prep-changelog.sh "$old_version" "$version"
 
     logecho "Next steps:"
     logecho "* Check all changes and add to a new commit"
+    logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -105,7 +105,7 @@ main() {
         sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
     fi
 
-    $DIR/../../Documentation/check-crd-compat-table.sh "$branch"
+    $DIR/../../Documentation/check-crd-compat-table.sh "$branch" --update
     if [ "${old_branch}" != "" ]; then
       $DIR/prep-changelog.sh "$old_version" "$version" "$old_branch"
     else

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -56,6 +56,10 @@ handle_args() {
         git status -s | grep -v "^??"
         common::exit 1 "Unmerged changes in tree prevent preparing release PR."
     fi
+
+    if ! gh auth status >/dev/null; then
+        common::exit 1 "Failed to authenticate with GitHub"
+    fi
 }
 
 main() {

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -8,6 +8,7 @@ source $DIR/lib/common.sh
 
 VERSION_GLOB='v[0-9]*\.[0-9]*\.[0-9]*'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+BRANCH_REGEX='s/\(v[0-9]*\.[0-9]*\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
@@ -105,7 +106,8 @@ main() {
         sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
     fi
 
-    $DIR/../../Documentation/check-crd-compat-table.sh "$branch" --update
+    target_branch=$(echo "$version" | sed "$BRANCH_REGEX")
+    $DIR/../../Documentation/check-crd-compat-table.sh "$target_branch" --update
     if [ "${old_branch}" != "" ]; then
       $DIR/prep-changelog.sh "$old_version" "$version" "$old_branch"
     else

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -7,7 +7,6 @@ source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-VERSION_TO_BRANCH_REGEX='s/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
@@ -42,7 +41,7 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"; then
+    if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
         common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
     fi
@@ -67,20 +66,18 @@ main() {
 
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
-    local branch="v$(echo $ersion | sed $VERSION_TO_BRANCH_REGEX)"
+    local branch="$(get_branch_from_version $REMOTE $version)"
     local new_proj="$2"
     local old_version=""
 
-    git fetch $REMOTE
-    if [ -n "$(git ls-remote --heads $REMOTE $branch)" ]; then
+    git fetch -q $REMOTE
+    if [ "$branch" = "master" ]; then
+        git checkout -b pr/prepare-$version $REMOTE/$branch
+        local old_branch="$(get_branch_from_version $REMOTE v$(cat VERSION))"
+        old_version="$(git show $old_branch:VERSION)"
+    else
         git checkout -b pr/prepare-$version $REMOTE/$branch
         old_version="$(cat VERSION)"
-    else
-        logecho "Cannot find $REMOTE/$branch. Basing release on master."
-        branch="master"
-        git checkout -b pr/prepare-$version $REMOTE/$branch
-        local old_branch="$(cat VERSION | sed $VERSION_TO_BRANCH_REGEX)"
-        old_version="$(git show v$old_branch:VERSION)"
     fi
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -7,7 +7,7 @@ source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 usage() {

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -88,7 +88,7 @@ main() {
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
-    logrun make RELEASE=yes CILIUM_BRANCH="$branch" -C install/kubernetes all USE_DIGESTS=false
+    logrun make RELEASE=yes -C install/kubernetes all USE_DIGESTS=false
     if grep -q update-helm-values Documentation/Makefile; then
         logrun make -C Documentation update-helm-values
     fi

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -25,7 +25,7 @@ usage() {
 # $1 - VERSION
 version_is_prerelease() {
     case "$1" in
-        *rc*|*snapshot*)
+        *pre*|*rc*|*snapshot*)
             return 0
             ;;
         *)
@@ -47,7 +47,7 @@ handle_args() {
 
     if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+        common::exit 1 "Invalid VERSION ARG \"$1\"; $RELEASE_FORMAT_MSG"
     fi
 
     if ! echo "$2" | grep -q "^[0-9]\+" && ! version_is_prerelease "$1"; then
@@ -84,7 +84,7 @@ main() {
     if [ "$branch" = "main" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
         if ! version_is_prerelease "$version"; then
-            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"
+            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'pre\|rc\|snapshot' | sort -V | tail -n 1)"
         else
             old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"
         fi

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -88,6 +88,7 @@ main() {
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
+    logrun make -C Documentation update-helm-values
     logrun make update-authors
     if ! version_is_prerelease "$version"; then
         old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -96,7 +96,7 @@ main() {
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
-    logrun make RELEASE=yes CILIUM_BRANCH="$branch" install/kubernetes all USE_DIGESTS=false
+    logrun make RELEASE=yes CILIUM_BRANCH="$branch" -C install/kubernetes all USE_DIGESTS=false
     if grep -q update-helm-values Documentation/Makefile; then
         logrun make -C Documentation update-helm-values
     fi

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -52,7 +52,6 @@ handle_args() {
 main() {
     handle_args "$@"
 
-    local old_version="$(cat VERSION)"
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
     local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
@@ -60,6 +59,7 @@ main() {
 
     git fetch $REMOTE
     git checkout -b pr/prepare-$version $REMOTE/$branch
+    local old_version="$(cat VERSION)"
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -88,7 +88,9 @@ main() {
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
-    logrun make -C Documentation update-helm-values
+    if grep -q update-helm-values Documentation/Makefile; then
+        logrun make -C Documentation update-helm-values
+    fi
     logrun make update-authors
     if ! version_is_prerelease "$version"; then
         old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -123,8 +123,6 @@ main() {
     logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
-
-    # Leave $version-changes.txt around for prep-release.sh usage later
 }
 
 main "$@"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -96,7 +96,7 @@ main() {
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
-    logrun make -C install/kubernetes all USE_DIGESTS=false
+    logrun make RELEASE=yes CILIUM_BRANCH="$branch" install/kubernetes all USE_DIGESTS=false
     if grep -q update-helm-values Documentation/Makefile; then
         logrun make -C Documentation update-helm-values
     fi

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -103,7 +103,7 @@ main() {
         target_branch=$(echo "$old_version" | sed "$BRANCH_REGEX")
         old_branch="$target_branch"
     fi
-    $DIR/../../Documentation/check-crd-compat-table.sh "$target_branch" --update
+    Documentation/check-crd-compat-table.sh "$target_branch" --update
     if [ "${old_branch}" != "" ]; then
       $DIR/prep-changelog.sh "$old_version" "$version" "$old_branch"
     else

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -6,6 +6,7 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
+VERSION_GLOB='v[0-9]*\.[0-9]*\.[0-9]*'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
@@ -73,8 +74,11 @@ main() {
     git fetch -q $REMOTE
     if [ "$branch" = "master" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
-        local old_branch="$(get_branch_from_version $REMOTE v$(cat VERSION))"
-        old_version="$(git show $old_branch:VERSION)"
+        if echo "$version" | grep -q 'rc'; then
+            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'snapshot' | sort -V | tail -n 1)"
+        else
+            old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"
+        fi
     else
         git checkout -b pr/prepare-$version $REMOTE/$branch
         old_version="$(cat VERSION)"

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -113,12 +113,12 @@ main() {
     else
       $DIR/prep-changelog.sh "$old_version" "$version"
     fi
-    git commit -a -s -m "Prepare for release $version"
 
     logecho "Next steps:"
-    logecho "* Check the new release commit with 'git show'"
+    logecho "* Check all changes and add to a new commit"
     logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
+    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
 
     # Leave $version-changes.txt around for prep-release.sh usage later

--- a/internal/start-release.sh
+++ b/internal/start-release.sh
@@ -118,7 +118,6 @@ main() {
     logecho "* Check all changes and add to a new commit"
     logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
-    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
 
     # Leave $version-changes.txt around for prep-release.sh usage later

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -50,7 +50,7 @@ if $GENERATE_SUMMARY; then
     CHANGELOG=$SUMMARY
     SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
     echo "Prepare for release $RELEASE" > $SUMMARY
-    if [ "$BRANCH" = "master" ]; then
+    if [ "$BRANCH" = "main" ]; then
         echo "" >> $SUMMARY
         echo "See the included CHANGELOG.md for a full list of changes." >> $SUMMARY
     else
@@ -64,7 +64,7 @@ echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push $USER_REMOTE "$PR_BRANCH"
 LABELS="kind/release"
-if [ "$BRANCH" != "master" ]; then
+if [ "$BRANCH" != "main" ]; then
     LABELS="$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
 fi
 hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -65,6 +65,6 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push $USER_REMOTE "$PR_BRANCH"
 LABELS="kind/release"
 if [ "$BRANCH" != "master" ]; then
-    labels = "$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
+    LABELS="$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
 fi
 hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -29,8 +29,8 @@ if ! git branch -a | grep -q "$REMOTE/$BRANCH$" || [ ! -e $SUMMARY ]; then
     exit 1
 fi
 
-if ! hub help | grep -q "pull-request"; then
-    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+if ! gh help | grep -q "pr"; then
+    echo "This tool relies on 'gh' from https://cli.github.com/." 1>&2
     echo "Please install this tool first." 1>&2
     exit 1
 fi
@@ -67,4 +67,4 @@ LABELS="kind/release"
 if [ "$BRANCH" != "main" ]; then
     LABELS="$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
 fi
-hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY
+gh pr create -b "$BRANCH" -l "$LABELS" -F $SUMMARY -t "$(head -n 1 $SUMMARY)"

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -9,10 +9,7 @@ source $DIR/lib/common.sh
 REMOTE="$(get_remote)"
 BRANCH="${1:-""}"
 if [ "$BRANCH" = "" ]; then
-    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')
-    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
-        BRANCH=master
-    fi
+    BRANCH="$(get_branch_from_version $REMOTE $(git symbolic-ref -q --short HEAD))"
 fi
 
 RELEASE="v$(cat VERSION)"

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -9,7 +9,7 @@ source $DIR/lib/common.sh
 REMOTE="$(get_remote)"
 BRANCH="${1:-""}"
 if [ "$BRANCH" = "" ]; then
-    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')
 fi
 BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 

--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -10,8 +10,10 @@ REMOTE="$(get_remote)"
 BRANCH="${1:-""}"
 if [ "$BRANCH" = "" ]; then
     BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')
+    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
+        BRANCH=master
+    fi
 fi
-BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 
 RELEASE="v$(cat VERSION)"
 SUMMARY=${2:-}
@@ -23,10 +25,10 @@ fi
 
 USER_REMOTE=$(get_user_remote ${3:-})
 
-if ! git branch -a | grep -q "$REMOTE/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+if ! git branch -a | grep -q "$REMOTE/$BRANCH$" || [ ! -e $SUMMARY ]; then
     echo "usage: $0 [branch version] [release-summary] [your remote]" 1>&2
     echo 1>&2
-    echo "Ensure 'branch version' is available in '$REMOTE' and the summary file exists" 1>&2
+    echo "Ensure '$BRANCH' is available in '$REMOTE' and the summary file exists" 1>&2
     exit 1
 fi
 
@@ -51,12 +53,21 @@ if $GENERATE_SUMMARY; then
     CHANGELOG=$SUMMARY
     SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
     echo "Prepare for release $RELEASE" > $SUMMARY
-    tail -n+4 $CHANGELOG >> $SUMMARY
+    if [ "$BRANCH" = "master" ]; then
+        echo "" >> $SUMMARY
+        echo "See the included CHANGELOG.md for a full list of changes." >> $SUMMARY
+    else
+        tail -n+4 $CHANGELOG >> $SUMMARY
+    fi
 fi
 
-echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+echo -e "Sending PR for branch $BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push $USER_REMOTE "$PR_BRANCH"
-hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY
+LABELS="kind/release"
+if [ "$BRANCH" != "master" ]; then
+    labels = "$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
+fi
+hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -57,8 +57,16 @@ main() {
         common::exit 1 "Generate release notes via contrib/release/start-release.sh"
     fi
 
+    git fetch $REMOTE
+
+    local commit="$(git rev-parse HEAD)"
+    BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
     echo "Current HEAD is:"
-    git log --oneline -1 $(git rev-parse HEAD)
+    git log --oneline -1 "$commit"
+    if ! commit_in_upstream "$commit" "$BRANCH"; then
+        common::exit 1 "Commit $commit not in $REMOTE/$BRANCH!"
+    fi
+
     echo "Create git tags for $version with this commit"
     if ! common::askyorn ; then
         common::exit 0 "Aborting release preparation."

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -60,10 +60,7 @@ main() {
     git fetch $REMOTE
 
     local commit="$(git rev-parse HEAD)"
-    BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
-    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
-        BRANCH="master"
-    fi
+    BRANCH="$(get_branch_from_version $REMOTE $(git symbolic-ref -q --short HEAD))"
     echo "Current HEAD is:"
     git log --oneline -1 "$commit"
     if ! commit_in_upstream "$commit" "$BRANCH"; then

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -53,10 +53,6 @@ main() {
     fi
     local version="v$ersion"
 
-    if [[ ! -e $version-changes.txt ]]; then
-        common::exit 1 "Generate release notes via contrib/release/start-release.sh"
-    fi
-
     git fetch $REMOTE
 
     local commit="$(git rev-parse HEAD)"
@@ -75,14 +71,6 @@ main() {
     logrun -s git tag -a $ersion -s -m "Release $version"
     logrun -s git tag -a $version -s -m "Release $version"
     logrun -s git push $REMOTE $version $ersion
-
-    # Leave $version-changes.txt around so we can generate release notes later
-    echo -e "$ersion\n" > $version-release-summary.txt
-    echo "We are pleased to release Cilium $version." >>  $version-release-summary.txt
-    tail -n+4 $version-changes.txt >> $version-release-summary.txt
-    logecho "Creating Github draft release"
-    logrun hub release create -d -F $version-release-summary.txt $version
-    logecho "Browse to $RELEASES_URL to see the draft release"
 
     logecho
     logecho "Next steps:"

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -61,6 +61,9 @@ main() {
 
     local commit="$(git rev-parse HEAD)"
     BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
+    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
+        BRANCH="master"
+    fi
     echo "Current HEAD is:"
     git log --oneline -1 "$commit"
     if ! commit_in_upstream "$commit" "$BRANCH"; then

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -7,8 +7,6 @@ source $DIR/lib/k8s-common.sh
 source $DIR/lib/common.sh
 
 REMOTE="$(get_remote)"
-CHARTS_PATH="${CHARTS_PATH:-$GOPATH/src/github.com/cilium/charts}"
-CHARTS_TOOL="prepare_artifacts.sh"
 RELEASES_URL="https://github.com/cilium/cilium/releases"
 VERSION=""
 
@@ -27,11 +25,6 @@ handle_args() {
 
     if [[ ! -e VERSION ]]; then
         common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
-    fi
-
-    if [[ ! -e "$CHARTS_PATH/$CHARTS_TOOL" ]]; then
-        usage
-        common::exit 1 "CHARTS_PATH='$CHARTS_PATH' invalid. Clone from github.com/cilium/charts"
     fi
 
     if ! which hub >/dev/null; then

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -27,8 +27,8 @@ handle_args() {
         common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
     fi
 
-    if ! which hub >/dev/null; then
-        echo "This tool relies on 'hub' from https://github.com/github/hub ." 1>&2
+    if ! which gh >/dev/null; then
+        echo "This tool relies on 'gh' from https://cli.github.com/ ." 1>&2
         common::exit 1 "Please install this tool first."
     fi
 

--- a/internal/tag-release.sh
+++ b/internal/tag-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/k8s-common.sh


### PR DESCRIPTION
**NOT** easier to review per commit.

To diff against [André's branch](https://github.com/cilium/release/tree/pr/add-release-scripts).

Recipe:

```bash
cd cilium
rm contrib/release/bump-docker-stable.sh contrib/release/check-docker-images.sh
git format-patch 7fa3c60eb7dbe7a5a4caea3aab0396f75a8b10c7 -o /tmp/foo contrib/release/**/** contrib/backporting/common.sh
cd ../release
git switch -c new-branch
git am -p3 --directory=internal /tmp/foo/*
git filter-branch -f --tree-filter "git mv -kf internal/lib/common.sh internal/lib/k8s-common.sh" master..
git filter-branch -f --tree-filter "git mv -kf internal/common.sh internal/lib/common.sh" master..
git filter-branch -f --msg-filter "sed '2a [ cherry-picked from cilium/cilium repository ]\n'" master..
# <Tinker a little to fix the include paths>
gh pr checkout 206
git checkout -
git cherry-pick pr/add-release-scripts
git rebase master new-branch --sign-off
```

The very last commit is the one with the changes to the issue templates from André's PR.