### PR TITLE
internal/submit-release

### DIFF
--- a/internal/submit-release.sh
+++ b/internal/submit-release.sh
@@ -67,4 +67,4 @@ LABELS="kind/release"
 if [ "$BRANCH" != "main" ]; then
     LABELS="$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
 fi
-gh pr create -b "$BRANCH" -l "$LABELS" -F $SUMMARY -t "$(head -n 1 $SUMMARY)"
+gh pr create -B "$BRANCH" -l "$LABELS" -F $SUMMARY -t "$(head -n 1 $SUMMARY)"


### PR DESCRIPTION
Fix flag in PR creation. When we refactored hub with gh, the flag should have also been renamed from `-b` to `-B`.

Fixes: cc1751db35a0 ("contrib/release: Switch from 'hub' to 'gh'")