### PR TITLE
Grep out version header while generating release notes

### DIFF
--- a/internal/post-release.sh
+++ b/internal/post-release.sh
@@ -69,7 +69,7 @@ main() {
 
     # Grab the release notes for the current release, stop before the next
     # release. The start of line `## vX.Y.Z` lines will match in command.
-    tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' > $version-release-summary.txt
+    tail -n+4 CHANGELOG.md | sed '/^## v.*$/q' | grep -v '^##' > $version-release-summary.txt
     tail -n+2 digest-$version.txt >> $version-release-summary.txt
     logecho "Creating Github draft release"
     prerelease=""


### PR DESCRIPTION
In my env, the command `tail -n+4 CHANGELOG.md | sed '/^## v.*$/q'` includes the version header of the previous command. Grep it out.

    % tail -n+4 CHANGELOG.md | sed '/^## v.*$/q'

    Summary of Changes
    ------------------

    **Minor Changes:**
    ...
    * Revert golang image version of hubble-relay (cilium/cilium#32732, @YutaroHayakawa)

    ## v1.15.5