### PR TITLE
changelog: Add --exclude-pr-references option

### DIFF
--- a/cmd/changelog/changelog.go
+++ b/cmd/changelog/changelog.go
@@ -20,11 +20,12 @@ var cfg ChangeLogConfig
 type ChangeLogConfig struct {
 	types.CommonConfig
 
-	Base         string
-	Head         string
-	LastStable   string
-	StateFile    string
-	LabelFilters []string
+	Base                string
+	Head                string
+	LastStable          string
+	StateFile           string
+	LabelFilters        []string
+	ExcludePRReferences bool
 }
 
 func (cfg *ChangeLogConfig) Sanitize() error {
@@ -66,6 +67,7 @@ func Command(ctx context.Context, logger *log.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.StateFile, "state-file", "release-state.json", "When set, it will use the already fetched information from a previous run")
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
 	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels")
+	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
 
 	for _, flag := range []string{"base", "head", "repo"} {
 		cobra.MarkFlagRequired(cmd.Flags(), flag)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,6 +99,7 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
 	cmd.Flags().BoolVar(&cfg.ForceMovePending, "force-move-pending-backports", false, "Force move pending backports to the next version's project")
 	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels")
+	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
 }
 
 func signals() {


### PR DESCRIPTION
--exclude-pr-references configures the `release` tool to not include references to pull requests in the generated changelog.

We have some internal projects that we would like to re-use the cilium/release tooling for, but since the projects are private, the references to the PR, repository and author is a bit unnecessary, and potentially confusing to end-users, so this PR adds an option to not include that information in the generated changelog.