### PR TITLE
changelog: Fix backport/upstream PR ordering

### DIFF
--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -176,7 +176,7 @@ func (cl *ChangeLog) PrintReleaseNotesForWriter(w io.Writer) {
 					printedReleaseNoteHeader = true
 				}
 
-				changelogItems = append(changelogItems, cl.prReleaseNote(pr, prID, &backportPR))
+				changelogItems = append(changelogItems, cl.prReleaseNote(pr, backportPR, &prID))
 				delete(listOfPRsUpstream, prID)
 			}
 		}


### PR DESCRIPTION
Previously, if a PR was merged upstream and then a backport created from
it, the tool would incorrectly output the backport / upstream PRs in the
wrong order, implying that the PR that is actually upstream is the one
that is the backport, and vice versa. Fix it.
