### PR TITLE
Add support for release-note/security label

### DIFF
--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -32,15 +32,17 @@ import (
 )
 
 var releaseNotes = map[string]string{
-	"release-note/major": "**Major Changes:**",
-	"release-note/minor": "**Minor Changes:**",
-	"release-note/bug":   "**Bugfixes:**",
-	"release-note/ci":    "**CI Changes:**",
-	"release-note/misc":  "**Misc Changes:**",
-	"release-note/none":  "**Other Changes:**",
+	"release-note/security": "**Important Security Updates:**",
+	"release-note/major":    "**Major Changes:**",
+	"release-note/minor":    "**Minor Changes:**",
+	"release-note/bug":      "**Bugfixes:**",
+	"release-note/ci":       "**CI Changes:**",
+	"release-note/misc":     "**Misc Changes:**",
+	"release-note/none":     "**Other Changes:**",
 }
 
 var defaultReleaseNotesOrder = []string{
+	"release-note/security",
 	"release-note/major",
 	"release-note/minor",
 	"release-note/bug",


### PR DESCRIPTION
Add support for organizing security updates in release notes into their own section. We're looking at using `cilium/release` for some internal projects and having a way to organize security updates/fixes separately from the other updates would be useful, so add support for a `release-note/security` label. 