### PR TITLE
Add flag to skip printing summary header

### DIFF
--- a/cmd/changelog/changelog.go
+++ b/cmd/changelog/changelog.go
@@ -23,6 +23,7 @@ type ChangeLogConfig struct {
 	StateFile           string
 	LabelFilters        []string
 	ExcludePRReferences bool
+	SkipHeader          bool
 }
 
 func (cfg *ChangeLogConfig) Sanitize() error {
@@ -67,6 +68,7 @@ func Command(ctx context.Context, logger *log.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
 	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels. This also defines the order of the release notes.")
 	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
+	cmd.Flags().BoolVar(&cfg.SkipHeader, "skip-header", false, "If true, do not print 'Summary of of changes' header")
 
 	for _, flag := range []string{"base", "head", "repo"} {
 		cobra.MarkFlagRequired(cmd.Flags(), flag)

--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -157,8 +157,10 @@ func GenerateReleaseNotes(globalCtx context.Context, ghClient *gh.Client, logger
 }
 
 func (cl *ChangeLog) PrintReleaseNotesForWriter(w io.Writer) {
-	fmt.Fprintln(w, "Summary of Changes")
-	fmt.Fprintln(w, "------------------")
+	if !cl.SkipHeader {
+		fmt.Fprintln(w, "Summary of Changes")
+		fmt.Fprintln(w, "------------------")
+	}
 
 	listOfPRs := cl.listOfPrs.DeepCopy()
 	prsWithUpstream := cl.prsWithUpstream.DeepCopy()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,6 +100,7 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&cfg.ForceMovePending, "force-move-pending-backports", false, "Force move pending backports to the next version's project")
 	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels")
 	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
+	cmd.Flags().BoolVar(&cfg.SkipHeader, "skip-header", false, "If true, do not print 'Summary of of changes' header")
 }
 
 func signals() {


### PR DESCRIPTION
We're using the release tool to generate new markdown docs files and want insert our own header and then append the output of release to generate the release changelog, so add an option to skip printing the "Summary of Changes" header at the top.