### PR TITLE
Differentiate between label-filter and release labels

### DIFF
--- a/cmd/changelog/changelog.go
+++ b/cmd/changelog/changelog.go
@@ -22,6 +22,7 @@ type ChangeLogConfig struct {
 	LastStable          string
 	StateFile           string
 	LabelFilters        []string
+	ReleaseLabels       []string
 	ExcludePRReferences bool
 	SkipHeader          bool
 }
@@ -66,7 +67,8 @@ func Command(ctx context.Context, logger *log.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.LastStable, "last-stable", "", "When last stable version is set, it will be used to detect if a bug was already backported or not to that particular branch (e.g.: '1.5', '1.6')")
 	cmd.Flags().StringVar(&cfg.StateFile, "state-file", "release-state.json", "When set, it will use the already fetched information from a previous run")
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
-	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels. This also defines the order of the release notes.")
+	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels.")
+	cmd.Flags().StringArrayVar(&cfg.ReleaseLabels, "release-labels", []string{}, "Specify release labels to consider when generating the changelog. This also defines the order of the release notes.")
 	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
 	cmd.Flags().BoolVar(&cfg.SkipHeader, "skip-header", false, "If true, do not print 'Summary of of changes' header")
 

--- a/cmd/changelog/labels.go
+++ b/cmd/changelog/labels.go
@@ -1,0 +1,15 @@
+package changelog
+
+import "slices"
+
+func filterByLabels(labels []string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for _, label := range labels {
+		if slices.Contains(filters, label) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/changelog/labels_test.go
+++ b/cmd/changelog/labels_test.go
@@ -1,0 +1,15 @@
+package changelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterByLabels(t *testing.T) {
+	assert.True(t, filterByLabels([]string{"label-a", "label-b", "label-c"}, []string{}))
+	assert.True(t, filterByLabels([]string{"label-a", "label-b", "label-c"}, []string{"label-a"}))
+	assert.True(t, filterByLabels([]string{"label-a", "label-b", "label-c"}, []string{"label-b"}))
+	assert.True(t, filterByLabels([]string{"label-a", "label-b", "label-c"}, []string{"label-c"}))
+	assert.False(t, filterByLabels([]string{"label-a", "label-b", "label-c"}, []string{"label-d"}))
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,7 +98,8 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cfg.StateFile, "state-file", "release-state.json", "When set, it will use the already fetched information from a previous run")
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
 	cmd.Flags().BoolVar(&cfg.ForceMovePending, "force-move-pending-backports", false, "Force move pending backports to the next version's project")
-	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels")
+	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels.")
+	cmd.Flags().StringArrayVar(&cfg.ReleaseLabels, "release-labels", []string{}, "Specify release labels to consider when generating the changelog. This also defines the order of the release notes.")
 	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
 	cmd.Flags().BoolVar(&cfg.SkipHeader, "skip-header", false, "If true, do not print 'Summary of of changes' header")
 }

--- a/pkg/github/release.go
+++ b/pkg/github/release.go
@@ -83,6 +83,7 @@ func GeneratePatchRelease(
 						ReleaseLabel:     getReleaseLabel(lbls),
 						AuthorName:       pr.GetUser().GetLogin(),
 						BackportBranches: getBackportBranches(lbls),
+						Labels:           lbls,
 					}
 					nodeIDs[pr.GetNumber()] = pr.GetNodeID()
 					continue
@@ -110,6 +111,7 @@ func GeneratePatchRelease(
 						ReleaseNote:  getReleaseNote(upstreamPR.GetTitle(), upstreamPR.GetBody()),
 						ReleaseLabel: getReleaseLabel(lbls),
 						AuthorName:   upstreamPR.GetUser().GetLogin(),
+						Labels:       lbls,
 					}
 					nodeIDs[pr.GetNumber()] = pr.GetNodeID()
 					nodeIDs[upstreamPR.GetNumber()] = upstreamPR.GetNodeID()

--- a/pkg/types/pull_request.go
+++ b/pkg/types/pull_request.go
@@ -21,6 +21,7 @@ type PullRequest struct {
 	// BackportBranches contains all the backport-done labels present in the
 	// PullRequest.
 	BackportBranches []string
+	Labels           []string
 }
 
 // NodeIDs maps a Pull Request number to its graphql node_id


### PR DESCRIPTION
Partially reverts the behavior change introduced by https://github.com/cilium/release/pull/238.

Filtering is still done in the changelog generation, but now we store all of the PR labels in the release-state and return to filtering against all the PR labels using --label-filter.

The newly introduced behavior in #238 is now part of the new --release-labels flag, which configures the release-labels to use when generating release notes.

CC @michi-covalent who noticed the behavior change.

This does require deleting your existing `release-state.json` since all PR labels are now being stored in the release-state.

```
(⎈|kind-kind:N/A) ~/p/w/cilium-oss ❯❯❯ GITHUB_TOKEN=$(gh auth token) /Users/chancez/projects/work/release/release changelog --base v1.16.0-pre.3 --head v1.16.0 --repo cilium/cilium --label-filter hubble-cli                                                                                                                                                                                                                  ✘ 127 main ✭
Comparing v1.16.0-pre.3...v1.16.0
Comparing v1.16.0-pre.3...369e927307d8780e0e6b5247d7e977bbd0fb8a05
Comparing v1.16.0-pre.3...a57393f33287cb65bd4be72c237a048ed457780f
Comparing v1.16.0-pre.3...deee47cac2f7c56d376e1877d1fb4bd9f3c9fd84
Comparing v1.16.0-pre.3...deee47cac2f7c56d376e1877d1fb4bd9f3c9fd84
Found 678 commits!
Preparing Changelog file  86% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████                                                    | (584/678, 3 it/s) [4m19s:33s]
WARNING: PR not found for commit 48a9976a09015a0e411997780c8b260d59593071!

Preparing Changelog file  86% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████                                                    | (585/678, 3 it/s) [4m19s:32s]
WARNING: PR not found for commit 568dbc5ad884e37614992f59ceb89ad89feb9135!

Preparing Changelog file 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (678/678, 2 it/s)           

State stored successful in release-state.json, please use --state-file=release-state.json in the next run to continue

Found 319 PRs and 10 backport PRs!

Found 1 PRs and 0 backport PRs in release-state.json based on --label-filter

Summary of Changes                                                                                                                                                                                                                                                                                                                                                                                                                          
------------------

**Minor Changes:**
* hubble: node labels (cilium/cilium#32851, @kaworu)
```