### PR TITLE
.github: Fix template formatting for announcements

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_patch_new.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch_new.md
@@ -116,6 +116,7 @@ vD.E.F: https://github.com/cilium/cilium/releases/tag/vD.E.F
 
 ### First pre-release
 
+```
 :cilium-new: *Cilium vX.Y.Z-rc.W has been released:*
 https://github.com/cilium/cilium/releases/tag/vX.Y.Z-rc.W
 


### PR DESCRIPTION
Fixes: 0b00175dc804 (".github: Add Slack announcement text templates")
