### PR TITLE
changelog: Do not add to a nil map

### DIFF
--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -178,6 +178,9 @@ func (cl *ChangeLog) PrintReleaseNotesForWriter(w io.Writer) {
 			if !filterByLabels(upstreamPR.Labels, cl.LabelFilters) {
 				continue
 			}
+			if prsWithUpstream[prNumber] == nil {
+				prsWithUpstream[prNumber] = make(types.PullRequests)
+			}
 			prsWithUpstream[prNumber][upstreamPRNumber] = upstreamPR
 		}
 	}


### PR DESCRIPTION
Initialize a nil map before writing to it.

From https://github.com/cilium/cilium/actions/runs/10349027982/job/28642554669:

panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/cilium/release/cmd/changelog.(*ChangeLog).PrintReleaseNotesForWriter(0xc0005f6270, {0xb0e140, 0xc0003a4090})
	/home/runner/work/cilium/release/cmd/changelog/generate.go:181 +0x170e
github.com/cilium/release/cmd/release.(*PrepareCommit).generateChangeLog(0xc000058128, {0xb12260, 0xc00007cb90}, 0xc0001e2b90)
	/home/runner/work/cilium/release/cmd/release/git.go:244 +0x40c
github.com/cilium/release/cmd/release.(*PrepareCommit).Run(0xc000058128, {0xb12260, 0xc00007cb90}, 0x5f?, 0x25?, 0xc0001e2b90)
	/home/runner/work/cilium/release/cmd/release/git.go:139 +0xc65
github.com/cilium/release/cmd/release.Command.func2(0xc000193208, {0xa39d47?, 0x4?, 0xa39d4b?})
	/home/runner/work/cilium/release/cmd/release/start.go:288 +0x98c
github.com/spf13/cobra.(*Command).execute(0xc000193208, {0xc00011e840, 0xb, 0xb})
	/home/runner/work/cilium/release/vendor/github.com/spf13/cobra/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xefc780)
	/home/runner/work/cilium/release/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/work/cilium/release/vendor/github.com/spf13/cobra/command.go:1039
main.main()
	/home/runner/work/cilium/release/cmd/main.go:115 +0x1a