### PR TITLE
Remove all newlines from changelog item output

### DIFF
--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -279,7 +279,7 @@ func (cl *ChangeLog) PrintReleaseNotesForWriter(w io.Writer) {
 			return strings.ToLower(changelogItems[i]) < strings.ToLower(changelogItems[j])
 		})
 		for _, changeLogItem := range changelogItems {
-			cl.Logger.Printf(changeLogItem)
+			cl.Logger.Println(changeLogItem)
 		}
 	}
 }

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -83,7 +83,7 @@ func Test_getReleaseNote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getReleaseNote(tt.args.title, tt.args.body); got != tt.want {
-				t.Errorf("getReleaseNote() = %v, want %v", got, tt.want)
+				t.Errorf("getReleaseNote() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This fixes the changelog output so it removes both it handles both `\n` and `\r\n`. I was finding that when I was outputting changelogs to a file, there were `^M` invisible characters in the output. This is because the previous code was only replacing `\n` but not the `\r`. When I query the GitHub API, newlines are typically delimited as `\r\n` so the code should accommodate this case. `bufio.Scanner` is designed to handle reading text line by line already, so I adapted the `textBlockBetween` to use `buffo.Scanner` while preserving existing behavior.