### PR TITLE
.github: Add step to release to close GH projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -66,6 +66,8 @@ assignees: ''
     - [ ] Check if the workflow was successful and check the PR opened by the
       Release bot.
 - [ ] Merge PR
+- [ ] This step opened a [GitHub project](https://github.com/orgs/cilium/projects?query=is%3Aopen++v+)
+      to track the PRs in the release. Close the corresponding project.
 
 ## Publish helm (run after docker images are published)
 


### PR DESCRIPTION
This needs to be manual for now apparently because of the issue documented here:

https://github.com/cilium/release/blob/0a6859a0cd119cd8390ef861a075b6289c8cacaa/cmd/release/projects.go#L159-L160