### PR TITLE
Fix truncated checklist issue generation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_pre_main.md
+++ b/.github/ISSUE_TEMPLATE/release_template_pre_main.md
@@ -1,7 +1,7 @@
 ---
 name: Release a new pre-release version of Cilium from the main branch
 about: Create a checklist for an upcoming release
-title: 'vX.Y.Z-pre.W release'
+title: 'vX.Y.Z-pre.N release'
 labels: kind/release
 assignees: ''
 
@@ -30,7 +30,7 @@ assignees: ''
       current backporter to merge the outstanding [backport PRs] and stop merging any new
       backport PRs until the GitHub issue is closed (to avoid generating incomplete
       release notes).
-- [ ] Run `./release start --steps 1-pre-check --target-version vX.Y.Z-pre.W`
+- [ ] Run `./release start --steps 1-pre-check --target-version vX.Y.Z-pre.N`
   - [ ] Check that there are no [release blockers] for the targeted release
         version.
   - [ ] Ensure that outstanding [backport PRs] are merged (these may be
@@ -43,7 +43,7 @@ assignees: ''
 ## Preparation PR (run ~1 day before release date. It can be re-run multiple times.)
 
 - [ ] Go to [release workflow] and Run the workflow from "Branch: main", for
-  step "2-prepare-release" and version for vX.Y.Z-pre.W
+  step "2-prepare-release" and version for vX.Y.Z-pre.N
   - [ ] Check if the workflow was successful and check the PR opened by the
         Release bot.
 - [ ] Merge PR
@@ -54,7 +54,7 @@ assignees: ''
 - [ ] FYI, do not wait too much time between a tag is created and the helm charts are published.
       Once the tags are published the documentation will be pointing to them. Until we release
       the helm chart, users will face issues while trying out our documentation.
-- [ ] Run `./release start --steps 3-tag --target-version vX.Y.Z-pre.W`
+- [ ] Run `./release start --steps 3-tag --target-version vX.Y.Z-pre.N`
 - [ ] Ask a maintainer to approve the build in the following link (keep the URL
       of the GitHub run to be used later):
       [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
@@ -62,13 +62,13 @@ assignees: ''
 ## Post Tagging (run after docker images are published)
 
 - [ ] Go to [release workflow] and Run the workflow from "Branch: main", for
-  step "4-post-release" and version for vX.Y.Z-pre.W
+  step "4-post-release" and version for vX.Y.Z-pre.N
     - [ ] Check if the workflow was successful. (There won't be a PR opened
       by this step)
 
 ## Publish helm (run after docker images are published)
 
-- [ ] Update helm charts `./release start --steps 5-publish-helm --target-version vX.Y.Z-pre.W`
+- [ ] Update helm charts `./release start --steps 5-publish-helm --target-version vX.Y.Z-pre.N`
 - [ ] Open [Charts Workflow] and check if the workflow run is successful.
 
 ## Publish docs (only for pre/rc releases)
@@ -106,9 +106,9 @@ assignees: ''
 ```
 :confetti_ball: :cilium-radiant: Release Announcement :cilium-radiant::confetti_ball:
 
-Cilium vX.Y.Z-pre.W, vA.B.C, and vD.E.F have been released. Thanks all for your contributions! Please see the release notes below for details :cilium-gopher:
+Cilium vX.Y.Z-pre.N, vA.B.C, and vD.E.F have been released. Thanks all for your contributions! Please see the release notes below for details :cilium-gopher:
 
-vX.Y.Z-pre.W: https://github.com/cilium/cilium/releases/tag/vX.Y.Z-pre.W
+vX.Y.Z-pre.N: https://github.com/cilium/cilium/releases/tag/vX.Y.Z-pre.N
 vA.B.C: https://github.com/cilium/cilium/releases/tag/vA.B.C
 vD.E.F: https://github.com/cilium/cilium/releases/tag/vD.E.F
 ```
@@ -116,10 +116,10 @@ vD.E.F: https://github.com/cilium/cilium/releases/tag/vD.E.F
 ### First pre-release
 
 ```
-:cilium-new: *Cilium vX.Y.Z-pre.W has been released:*
-https://github.com/cilium/cilium/releases/tag/vX.Y.Z-pre.W
+:cilium-new: *Cilium vX.Y.Z-pre.N has been released:*
+https://github.com/cilium/cilium/releases/tag/vX.Y.Z-pre.N
 
-This is the first monthly snapshot for the vX.Y development cycle. There are [vX.Y.Z-pre.W OSS docs](https://docs.cilium.io/en/vX.Y.Z-pre.W) available if you want to pull this version & try it out.
+This is the first monthly snapshot for the vX.Y development cycle. There are [vX.Y.Z-pre.N OSS docs](https://docs.cilium.io/en/vX.Y.Z-pre.N) available if you want to pull this version & try it out.
 ```
 
 ### Subsequent pre-/rc- releases
@@ -127,10 +127,10 @@ This is the first monthly snapshot for the vX.Y development cycle. There are [vX
 ```
 *Announcement* :tada: :tada:
 
-:cilium-new: *Cilium vX.Y.Z-pre.W has been released:*
-https://github.com/cilium/cilium/releases/tag/vX.Y.Z-pre.W
+:cilium-new: *Cilium vX.Y.Z-pre.N has been released:*
+https://github.com/cilium/cilium/releases/tag/vX.Y.Z-pre.N
 
-Thank you for the testing and contributing to the previous pre-releases. There are [vX.Y.Z-pre.W OSS docs](https://docs.cilium.io/en/vX.Y.Z-pre.W) available if you want to pull this version & try it out.
+Thank you for the testing and contributing to the previous pre-releases. There are [vX.Y.Z-pre.N OSS docs](https://docs.cilium.io/en/vX.Y.Z-pre.N) available if you want to pull this version & try it out.
 ```
 
 [release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -55,7 +55,7 @@ assignees: ''
       - Use the settings of the previous stable branch and main as sane defaults
   - [ ] On the `vX.Y` branch, prepare for stable release development:
     - [ ] Update the VERSION file with the last prerelease for this stable version
-      - `echo "X.Y.Z-pre.N" > VERSION`
+      - `echo "X.Y.Z-rc.W" > VERSION`
     - [ ] Remove any GitHub workflows from the stable branch that are only
           relevant for the main branch.
       - Remove workflows that are exclusively triggered by cron job and

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ all: tests release
 docker-image:
 	docker build $(DOCKER_BUILD_FLAGS) -t cilium/release-tool:${IMAGE_TAG} .
 
+.PHONY: generate-golden
+generate-golden:
+	$(MAKE) $(patsubst %.input,%.golden,$(shell find ./testdata/checklist/ -name "*.input"))
+
+%.golden: %.input
+	$(GO) run ./cmd/ checklist open --dry-run \
+		--target-version "v1.10.0-pre.0" \
+		--template $< \
+		> $@ \
+
 .PHONY: tests
 tests:
 	$(GO) test -mod=vendor ./...

--- a/cmd/checklist/open.go
+++ b/cmd/checklist/open.go
@@ -70,16 +70,20 @@ func OpenCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 				return fmt.Errorf("Failed to validate configuration: %s", err)
 			}
 
-			tmpl, err := prepareChecklist(cfg)
+			tmpl, err := fetchTemplate(cfg)
+			if err != nil {
+				return fmt.Errorf("Failed to fetch template: %w", err)
+			}
+			cl, err := prepareChecklist(tmpl, cfg)
 			if err != nil {
 				return fmt.Errorf("Failed to apply template configuration to template: %s", err)
 			}
 			if cfg.DryRun {
-				fmt.Printf("%s", tmpl)
+				fmt.Printf("%s", cl)
 				return nil
 			}
 
-			return CreateIssue(ctx, ghClient, cfg, tmpl)
+			return CreateIssue(ctx, ghClient, cfg, cl)
 		},
 	}
 	cmd.Flags().StringVar(&cfg.TemplatePath, "template", "", "Template path to create release checklist")

--- a/cmd/checklist/template.go
+++ b/cmd/checklist/template.go
@@ -78,12 +78,7 @@ func assembleVersionSubstitutions(version string) ([]string, error) {
 	return result, nil
 }
 
-func prepareChecklist(cfg ChecklistConfig) (string, error) {
-	tmpl, err := fetchTemplate(cfg)
-	if err != nil {
-		return "", fmt.Errorf("Failed to fetch template: %w", err)
-	}
-
+func prepareChecklist(tmpl []byte, cfg ChecklistConfig) (string, error) {
 	patterns, err := assembleVersionSubstitutions(cfg.TargetVer)
 	if err != nil {
 		return "", fmt.Errorf("Error while parsing version %q: %w", cfg.TargetVer, err)

--- a/cmd/checklist/template.go
+++ b/cmd/checklist/template.go
@@ -102,7 +102,7 @@ func templateToRequest(tmpl string) (*gh.IssueRequest, error) {
 		return nil, fmt.Errorf("unable to find metadata, body in issue template, check form of %s", cfg.TemplatePath)
 	}
 	meta := segments[1]
-	body := segments[2]
+	body := strings.Join(segments[2:], "---")
 
 	titleRe := regexp.MustCompile(`title: '(.*)'\n`)
 	match := titleRe.FindStringSubmatch(meta)

--- a/cmd/checklist/template_test.go
+++ b/cmd/checklist/template_test.go
@@ -4,6 +4,8 @@
 package checklist
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,5 +71,36 @@ func Test_assembleVersionSubstitutions(t *testing.T) {
 			assert.ErrorContains(t, err, tt.err, tt.name+" encountered unexpected error")
 		}
 		assert.Equal(t, sub, tt.want, tt.name+" generated unexpected substitutions")
+	}
+}
+
+func Test_prepareChecklist(t *testing.T) {
+	cfg := ChecklistConfig{
+		TargetVer: "v1.10.0-pre.0",
+	}
+	testdataPath := filepath.Join("..", "..", "testdata", "checklist")
+
+	paths, err := filepath.Glob(filepath.Join(testdataPath, "*.input"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range paths {
+		_, filename := filepath.Split(path)
+		testname := filename[:len(filename)-len(filepath.Ext(path))]
+
+		t.Run(testname, func(t *testing.T) {
+			source, err := os.ReadFile(path)
+			assert.Nil(t, err, "failed to read input template: ", err)
+
+			output, err := prepareChecklist(source, cfg)
+			assert.Nil(t, err, "failed to render checklist: ", err)
+
+			golden := filepath.Join(testdataPath, testname+".golden")
+			want, err := os.ReadFile(golden)
+			assert.Nil(t, err, "error reading golden output: ", err)
+
+			assert.Equal(t, output, string(want), "template processing did not match golden output. Check for bugs or run 'make generate-golden' to update the golden tests.")
+		})
 	}
 }

--- a/cmd/checklist/template_test.go
+++ b/cmd/checklist/template_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package checklist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_assembleVersionSubstitutions(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   string
+		input string
+		want  []string
+	}{
+		{
+			name:  "Invalid input",
+			input: "foo",
+			want:  nil,
+			err:   "unexpected version string foo",
+		},
+		{
+			name:  "Stable release",
+			input: "v1.10.0",
+			want: []string{
+				"X.Y.Z-rc.W", "",
+				"X.Y.Z-pre.N", "",
+				"X.Y.Z", "1.10.0",
+				"X.Y.W", "1.10.1",
+				"X.Y-1", "1.9",
+				"X.Y+1", "1.11",
+				"X.Y", "1.10",
+			},
+		},
+		{
+			name:  "Release candidate",
+			input: "v1.10.0-rc.0",
+			want: []string{
+				"X.Y.Z-rc.W", "1.10.0-rc.0",
+				"X.Y.Z-pre.N", "1.10.0-rc.0",
+				"X.Y.Z", "1.10.0",
+				"X.Y.W", "1.10.1",
+				"X.Y-1", "1.9",
+				"X.Y+1", "1.11",
+				"X.Y", "1.10",
+			},
+		},
+		{
+			name:  "Prerelease",
+			input: "v1.10.0-pre.0",
+			want: []string{
+				"X.Y.Z-rc.W", "1.10.0-pre.0",
+				"X.Y.Z-pre.N", "1.10.0-pre.0",
+				"X.Y.Z", "1.10.0",
+				"X.Y.W", "1.10.1",
+				"X.Y-1", "1.9",
+				"X.Y+1", "1.11",
+				"X.Y", "1.10",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		sub, err := assembleVersionSubstitutions(tt.input)
+		if tt.err != "" {
+			assert.ErrorContains(t, err, tt.err, tt.name+" encountered unexpected error")
+		}
+		assert.Equal(t, sub, tt.want, tt.name+" generated unexpected substitutions")
+	}
+}

--- a/testdata/checklist/release_template_minor.md.golden
+++ b/testdata/checklist/release_template_minor.md.golden
@@ -1,0 +1,127 @@
+---
+name: Release a new minor version of Cilium from a stable branch
+about: Create a checklist for an upcoming release
+title: 'v1.10.0 release'
+labels: kind/release
+assignees: ''
+
+---
+
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
+- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
+- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
+
+          git checkout master && git pull && make
+
+## Pre-release
+
+- [ ] Announce in Cilium slack channel #launchpad: `Starting v1.10.0 release process :ship:`
+- [ ] Create a thread for that message and ping current top-hat to not merge any
+      PRs until the release process is complete.
+- [ ] Change directory to the local copy of Cilium repository.
+- [ ] Check that there are no [release blockers] for the targeted release version
+- [ ] Ensure that outstanding [backport PRs] are merged
+- [ ] Check with @cilium/security team if there are any security fixes to include
+      in the release.
+- [ ] Execute `release --current-version 1.10.0 --next-dev-version 1.10.1` to
+      automatically move any unresolved issues/PRs from old release project
+      into the new project. The `release` binary is located in the
+      [current repository][Cilium release-notes tool].
+- [ ] Push a PR including the changes necessary for the new release:
+  - [ ] Pull latest changes from the branch being released
+  - [ ] The next step will generate a `CHANGELOG.md` that will not be correct.
+        That is expected, and it is fixed with a follow-up step. Don't worry.
+  - [ ] Run `../release/internal/start-release.sh 1.10.0 <GH-PROJECT> 1.9`
+        Note that this script produces some files at the root of the Cilium
+        repository, and that these files are required at a later step for
+        tagging the release.
+  - [ ] `rm CHANGELOG.md`
+  - [ ] Regenerate the log since the previous release with `prep-changelog.sh <last-patch-release> v1.10.0`
+  - [ ] Check and edit the `CHANGELOG.md` to ensure all PRs have proper release notes
+  - [ ] Edit the `v1.10.0-changes.txt` files locally to replace the text with "See CHANGELOG.md for more details"
+  - [ ] Add the 'stable' tag as part of the GitHub workflow and remove the
+        'stable' tag from the last stable branch.
+  - [ ] Commit all changes with title `Prepare for release v1.10.0`
+  - [ ] Submit PR (`../release/internal/submit-release.sh`)
+  - [ ] Submit a PR that removes the 'stable' tag from the last stable branch.
+- [ ] Merge PR
+- [ ] Create and push *both* tags to GitHub (`v1.10.0`, `1.10.0`)
+  - [ ] Pull latest branch locally and run `../release/internal/tag-release.sh`.
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
+      of the GitHub run to be used later):
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+  - [ ] Check if all docker images are available before announcing the release:
+        `make -C install/kubernetes/ check-docker-images`
+- [ ] Get the image digests from the build process and make a commit and PR with
+      these digests.
+  - [ ] Run `../release/internal/post-release.sh URL` to fetch the image
+        digests and submit a PR to update these, use the `URL` of the GitHub
+        run here
+  - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
+        wait for the automatic checks to complete. Merge the PR.
+- [ ] Update helm charts
+  - [ ] Create helm charts artifacts in [Cilium charts] repository using
+        [cilium helm release tool] for the `v1.10.0` release.
+  - [ ] Check the output of the [chart workflow] and see if the test was
+        successful.
+- [ ] Check [read the docs] configuration:
+    - [ ] Set the [default version] and mark the EOL version as active, and
+          hidden and configure the new minor version as active and **not**
+          hidden in [active versions].
+    - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
+- [ ] Check draft release from [releases] page
+  - [ ] Update the text at the top with 2-3 highlights of the release
+  - [ ] Publish the release
+- [ ] Announce the release in #general on Slack (Use [@]channel for v1.10.0)
+- [ ] Update Grafana dashboards
+
+## Post-release
+
+- [ ] Update the upgrade guide and [roadmap](https://github.com/cilium/cilium/blob/main/Documentation/community/roadmap.rst) for any features that changed status.
+- [ ] For new minor version update [security policy]
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`
+  - [ ] Make sure to update the `.github/maintainers-little-helper.yaml` so that
+        upcoming PRs are tracked correctly for the next release.
+  - [ ] Bump the main testsuite to upgrade from v1.10 branch to main
+  - [ ] `echo 1.10.0 > stable.txt`.
+  - [ ] `echo '{"results":[{"slug":"v1.10"}]}' > Documentation/_static/stable-version.json`.
+  - [ ] Commit / amend the commit to add all of the changes above and push the PR.
+  - [ ] Merge the post-release PR.
+- [ ] Notify #development on Slack that deprecated features may now be removed.
+- [ ] This is the list of links for known external installers that depend on
+      the release process. Ideally, work toward updating external tools and
+      guides to point to the new Cilium version. If you find where to submit
+      the update, please add the relevant links to this template.
+  - [kops]
+  - [kubespray]
+  - [network policy]
+  - [cluster administration networking]
+  - [cluster administration addons]
+
+
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
+[release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2F1.10
+[backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2F1.10
+[Cilium release-notes tool]: https://github.com/cilium/release
+[Cilium charts]: https://github.com/cilium/charts
+[releases]: https://github.com/cilium/cilium/releases
+[kops]: https://github.com/kubernetes/kops/
+[kubespray]: https://github.com/kubernetes-sigs/kubespray/
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
+[cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
+[read the docs]: https://readthedocs.org/projects/cilium/
+[active versions]: https://readthedocs.org/projects/cilium/versions/
+[default version]: https://readthedocs.org/dashboard/cilium/advanced/
+[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
+[security policy]: https://github.com/cilium/cilium/security/policy
+[network policy]: https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/
+[cluster administration networking]: https://kubernetes.io/docs/concepts/cluster-administration/networking/
+[cluster administration addons]: https://kubernetes.io/docs/concepts/cluster-administration/addons/
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/testdata/checklist/release_template_minor.md.input
+++ b/testdata/checklist/release_template_minor.md.input
@@ -1,0 +1,1 @@
+../../.github/ISSUE_TEMPLATE/release_template_minor.md

--- a/testdata/checklist/release_template_patch.md.golden
+++ b/testdata/checklist/release_template_patch.md.golden
@@ -1,0 +1,150 @@
+---
+name: NEW Release a new patch version of Cilium from a stable branch
+about: Create a checklist for an upcoming release
+title: 'v1.10.0 release'
+labels: kind/release
+assignees: ''
+
+---
+
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo,project) that has access to the repository. Only classic tokens are
+      [supported at the moment][GitHub PAT tracker], the needed scopes are `write:org`, `public_repo` and `project`.
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags]
+  with Git and install [gh](https://cli.github.com).
+- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
+
+          git checkout main && git pull && make
+- [ ] Read the documentation of `release start --help` tool to understand what
+  each automated step does.
+
+## Pre-check (run ~1 week before release date)
+
+- [ ] When you create a GitHub issue using this issue template, GitHub Slack app posts a
+      message in #launchpad Slack channel. Create a thread for that message and ping the
+      current backporter to merge the outstanding [backport PRs] and stop merging any new
+      backport PRs until the GitHub issue is closed (to avoid generating incomplete
+      release notes).
+- [ ] Run `./release start --steps 1-pre-check --target-version v1.10.0`
+  - [ ] Check that there are no [release blockers] for the targeted release
+        version.
+  - [ ] Ensure that outstanding [backport PRs] are merged (these may be
+        skipped on case by case basis in coordination with the backporter).
+  - [ ] Check with @cilium/security team in case there are any CVEs found in the
+        docker image.
+  - [ ] Check with @cilium/security team if there are any security fixes to
+        include in the release.
+
+## Preparation PR (run ~1 day before release date. It can be re-run multiple times.)
+
+- [ ] Go to [release workflow] and Run the workflow from "Branch: main", for
+  step "2-prepare-release" and version for v1.10.0
+  - [ ] Check if the workflow was successful and check the PR opened by the
+        Release bot.
+- [ ] Merge PR
+
+## Tagging
+
+- [ ] Ask a maintainer if there are any known issues that should hold up the release
+- [ ] FYI, do not wait too much time between a tag is created and the helm charts are published.
+      Once the tags are published the documentation will be pointing to them. Until we release
+      the helm chart, users will face issues while trying out our documentation.
+- [ ] Run `./release start --steps 3-tag --target-version v1.10.0`
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
+      of the GitHub run to be used later):
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+
+## Post Tagging (run after docker images are published)
+
+- [ ] Go to [release workflow] and Run the workflow from "Branch: main", for
+  step "4-post-release" and version for v1.10.0
+    - [ ] Check if the workflow was successful and check the PR opened by the
+      Release bot.
+- [ ] Merge PR
+- [ ] This step opened a [GitHub project](https://github.com/orgs/cilium/projects?query=is%3Aopen++v+)
+      to track the PRs in the release. Close the corresponding project.
+
+## Publish helm (run after docker images are published)
+
+- [ ] Update helm charts `./release start --steps 5-publish-helm --target-version v1.10.0`
+- [ ] Open [Charts Workflow] and check if the workflow run is successful.
+
+## Publish docs (only for pre/rc releases)
+
+- [ ] Check [read the docs] configuration:
+  - [ ] Set a new build as active and hidden in [active versions].
+  - [ ] Deactivate previous RCs.
+  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
+    - Update the versions in `docsearch.config.json`, commit them and push a
+      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
+
+## Post-release
+
+- [ ] Check draft release from [releases] page
+  - [ ] Update the text at the top with 2-3 highlights of the release
+  - [ ] Check with @cilium/security if the release addresses any open security
+        advisory. If it does, include the list of security advisories at the
+        top of the release notes.
+  - [ ] Check whether the new release should be set as the _latest_ release
+        (via the checkbox at the bottom of the page). It should be the new
+        _latest_ if the version number is strictly superior to the current
+        _latest_ release displayed on GitHub (e.g. 1.11.13 does not become the
+        new latest release over 1.12.5, but version 1.12.6 will).
+  - [ ] Publish the release
+- [ ] Announce the release in #general on Slack (do not use [@]channel).
+      See below for templates.
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`.
+
+---
+
+## Slack example text templates
+
+### Patch releases
+
+```
+:confetti_ball: :cilium-radiant: Release Announcement :cilium-radiant::confetti_ball:
+
+Cilium v1.10.0, vA.B.C, and vD.E.F have been released. Thanks all for your contributions! Please see the release notes below for details :cilium-gopher:
+
+v1.10.0: https://github.com/cilium/cilium/releases/tag/v1.10.0
+vA.B.C: https://github.com/cilium/cilium/releases/tag/vA.B.C
+vD.E.F: https://github.com/cilium/cilium/releases/tag/vD.E.F
+```
+
+### First pre-release
+
+```
+:cilium-new: *Cilium v1.10.0-pre.0 has been released:*
+https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+
+This is the first monthly snapshot for the v1.10 development cycle. There are [v1.10.0-pre.0 OSS docs](https://docs.cilium.io/en/v1.10.0-pre.0) available if you want to pull this version & try it out.
+```
+
+### Subsequent pre-/rc- releases
+
+```
+*Announcement* :tada: :tada:
+
+:cilium-new: *Cilium v1.10.0-pre.0 has been released:*
+https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+
+Thank you for the testing and contributing to the previous pre-releases. There are [v1.10.0-pre.0 OSS docs](https://docs.cilium.io/en/v1.10.0-pre.0) available if you want to pull this version & try it out.
+```
+
+[release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml
+[GitHub PAT tracker]: https://github.com/orgs/community/discussions/36441
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
+[release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2F1.10
+[backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+draft%3Afalse+label%3Abackport%2F1.10
+[Cilium release-notes tool]: https://github.com/cilium/release
+[Cilium charts]: https://github.com/cilium/charts
+[Charts Workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml
+[releases]: https://github.com/cilium/cilium/releases
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
+[cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/testdata/checklist/release_template_patch.md.input
+++ b/testdata/checklist/release_template_patch.md.input
@@ -1,0 +1,1 @@
+../../.github/ISSUE_TEMPLATE/release_template_patch.md

--- a/testdata/checklist/release_template_pre_main.md.golden
+++ b/testdata/checklist/release_template_pre_main.md.golden
@@ -1,0 +1,147 @@
+---
+name: Release a new pre-release version of Cilium from the main branch
+about: Create a checklist for an upcoming release
+title: 'v1.10.0-pre.0 release'
+labels: kind/release
+assignees: ''
+
+---
+
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo,project) that has access to the repository. Only classic tokens are
+      [supported at the moment][GitHub PAT tracker], the needed scopes are `write:org`, `public_repo` and `project`.
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags]
+  with Git and install [gh](https://cli.github.com).
+- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
+
+          git checkout master && git pull && make
+- [ ] Read the documentation of `release start --help` tool to understand what
+  each automated step does.
+
+## Pre-check (run ~1 week before release date)
+
+- [ ] When you create a GitHub issue using this issue template, GitHub Slack app posts a
+      message in #launchpad Slack channel. Create a thread for that message and ping the
+      current backporter to merge the outstanding [backport PRs] and stop merging any new
+      backport PRs until the GitHub issue is closed (to avoid generating incomplete
+      release notes).
+- [ ] Run `./release start --steps 1-pre-check --target-version v1.10.0-pre.0`
+  - [ ] Check that there are no [release blockers] for the targeted release
+        version.
+  - [ ] Ensure that outstanding [backport PRs] are merged (these may be
+        skipped on case by case basis in coordination with the backporter).
+  - [ ] Check with @cilium/security team in case there are any CVEs found in the
+        docker image.
+  - [ ] Check with @cilium/security team if there are any security fixes to
+        include in the release.
+
+## Preparation PR (run ~1 day before release date. It can be re-run multiple times.)
+
+- [ ] Go to [release workflow] and Run the workflow from "Branch: main", for
+  step "2-prepare-release" and version for v1.10.0-pre.0
+  - [ ] Check if the workflow was successful and check the PR opened by the
+        Release bot.
+- [ ] Merge PR
+
+## Tagging
+
+- [ ] Ask a maintainer if there are any known issues that should hold up the release
+- [ ] FYI, do not wait too much time between a tag is created and the helm charts are published.
+      Once the tags are published the documentation will be pointing to them. Until we release
+      the helm chart, users will face issues while trying out our documentation.
+- [ ] Run `./release start --steps 3-tag --target-version v1.10.0-pre.0`
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
+      of the GitHub run to be used later):
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+
+## Post Tagging (run after docker images are published)
+
+- [ ] Go to [release workflow] and Run the workflow from "Branch: main", for
+  step "4-post-release" and version for v1.10.0-pre.0
+    - [ ] Check if the workflow was successful. (There won't be a PR opened
+      by this step)
+
+## Publish helm (run after docker images are published)
+
+- [ ] Update helm charts `./release start --steps 5-publish-helm --target-version v1.10.0-pre.0`
+- [ ] Open [Charts Workflow] and check if the workflow run is successful.
+
+## Publish docs (only for pre/rc releases)
+
+- [ ] Check [read the docs] configuration:
+  - [ ] Set a new build as active and hidden in [active versions].
+  - [ ] Deactivate previous RCs.
+  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
+    - Update the versions in `docsearch.config.json`, commit them and push a
+      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
+
+## Post-release
+
+- [ ] Check draft release from [releases] page
+  - [ ] Update the text at the top with 2-3 highlights of the release
+  - [ ] Check with @cilium/security if the release addresses any open security
+        advisory. If it does, include the list of security advisories at the
+        top of the release notes.
+  - [ ] Check whether the new release should be set as the _latest_ release
+        (via the checkbox at the bottom of the page). It should be the new
+        _latest_ if the version number is strictly superior to the current
+        _latest_ release displayed on GitHub (e.g. 1.11.13 does not become the
+        new latest release over 1.12.5, but version 1.12.6 will).
+  - [ ] Publish the release
+- [ ] Announce the release in #general on Slack (do not use [@]channel).
+      See below for templates.
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`.
+
+---
+
+## Slack example text templates
+
+### Patch releases
+
+```
+:confetti_ball: :cilium-radiant: Release Announcement :cilium-radiant::confetti_ball:
+
+Cilium v1.10.0-pre.0, vA.B.C, and vD.E.F have been released. Thanks all for your contributions! Please see the release notes below for details :cilium-gopher:
+
+v1.10.0-pre.0: https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+vA.B.C: https://github.com/cilium/cilium/releases/tag/vA.B.C
+vD.E.F: https://github.com/cilium/cilium/releases/tag/vD.E.F
+```
+
+### First pre-release
+
+```
+:cilium-new: *Cilium v1.10.0-pre.0 has been released:*
+https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+
+This is the first monthly snapshot for the v1.10 development cycle. There are [v1.10.0-pre.0 OSS docs](https://docs.cilium.io/en/v1.10.0-pre.0) available if you want to pull this version & try it out.
+```
+
+### Subsequent pre-/rc- releases
+
+```
+*Announcement* :tada: :tada:
+
+:cilium-new: *Cilium v1.10.0-pre.0 has been released:*
+https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+
+Thank you for the testing and contributing to the previous pre-releases. There are [v1.10.0-pre.0 OSS docs](https://docs.cilium.io/en/v1.10.0-pre.0) available if you want to pull this version & try it out.
+```
+
+[release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml
+[GitHub PAT tracker]: https://github.com/orgs/community/discussions/36441
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
+[release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2F1.10
+[backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+draft%3Afalse+label%3Abackport%2F1.10
+[Cilium release-notes tool]: https://github.com/cilium/release
+[Cilium charts]: https://github.com/cilium/charts
+[Charts Workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml
+[releases]: https://github.com/cilium/cilium/releases
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
+[cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/testdata/checklist/release_template_pre_main.md.input
+++ b/testdata/checklist/release_template_pre_main.md.input
@@ -1,0 +1,1 @@
+../../.github/ISSUE_TEMPLATE/release_template_pre_main.md

--- a/testdata/checklist/release_template_rc_branch.md.golden
+++ b/testdata/checklist/release_template_rc_branch.md.golden
@@ -1,0 +1,178 @@
+---
+name: Release a new RC version of Cilium from a stable branch
+about: Create a checklist for an upcoming release
+title: 'v1.10.0-pre.0 release'
+labels: kind/release
+assignees: ''
+
+---
+
+## Setup preparation
+
+- [ ] Depending on your OS, make sure Docker is running
+- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
+- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
+- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
+- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
+  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+
+## Pre-release
+
+
+- [ ] Announce in Cilium slack channel #launchpad: `Starting v1.10.0-pre.0 release process :ship:`
+- [ ] Create a thread for that message and ping current top-hat to not merge any
+  PRs until the release process is complete.
+- [ ] Change directory to the local copy of Cilium repository.
+- [ ] Check that there are no [release blockers] for the targeted release version
+- [ ] Ensure that outstanding [backport PRs] are merged
+- [ ] If stable branch is not created yet. Run:
+  - `git fetch upstream && git checkout -b upstream/v1.10 upstream/main`
+  - [ ] Push that branch to GitHub:
+    - `git push upstream v1.10`
+  - [ ] On the main branch, create a PR with a change in the `VERSION` file to
+        start the next development cycle as well as creating the necessary GH
+        workflows (renovate configuration, MLH configuration, etc.
+        see [24143732b616](https://github.com/cilium/cilium/commit/24143732b616bb6cd308564b0be33f13fc5613e6)
+        for reference):
+    - [ ] Adjust `maintainers-little-helper.yaml` accordingly the new stable
+          branch.
+    - [ ] Check for any other .github workflow references to the current stable
+          branch `1.9`, and update those to include the new stable `1.10`
+          version as well.
+        - `git grep "1.9" .github/`
+    - [ ] Ensure that the `CustomResourceDefinitionSchemaVersion` uses a new
+          minor schema version compared to the new `1.10` release.
+    - `echo "1.11.0-dev" > VERSION`
+    - `make -C install/kubernetes`
+    - `git add .github/ Documentation/contributing/testing/ci.rst`
+    - `git commit -sam "Prepare for v1.11 development cycle"`
+  - [ ] Merge the main PR so that the stable branch protection can be properly
+        set up with the right status checks requirements.
+  - [ ] Sync the `v1.10` branch up to the commit before preparing for the `1.11` development cycle.
+    - `git fetch upstream && git checkout v1.10 && git merge --ff-only upstream/main~1 && git log -5`
+    - `git push upstream v1.10`
+  - [ ] Protect the new stable branch with GitHub Settings [here](https://github.com/cilium/cilium/settings/branches)
+      - Use the settings of the previous stable branch and main as sane defaults
+  - [ ] On the `v1.10` branch, prepare for stable release development:
+    - [ ] Update the VERSION file with the last prerelease for this stable version
+      - `echo "1.10.0-pre.0" > VERSION`
+    - [ ] Remove any GitHub workflows from the stable branch that are only
+          relevant for the main branch.
+      - Remove workflows that are exclusively triggered by cron job and
+        workflows triggered by `issue_comment` triggers, as they do not run on
+        stable branches. These can be identified with commands like this:
+        - `git grep -B 5 cron .github/ | grep name | sed 's/-name.*//g'`
+        - `git grep issue_comment .github/`
+      - Replace references to `main` branch with `1.10` in the workflows.
+        - `sed -i 's/- \(ft\/\)\?main/- \1v1.10/g' .github/workflows/*`
+        - `sed -i 's/@main/@v1.10/g' .github/workflows/*`
+        - `sed -i 's/\/main\//\/v1.10\//g' .github/workflows/*`
+      - Ensure that the `CustomResourceDefinitionSchemaVersion` uses a new
+        minor schema version compared to the previous stable release.
+      - Update `install/kubernetes/Makefile*`, following the changes made
+        during the previous stable branch preparation commit on the previous
+        stable branch.
+      - Remove `stable.txt` file
+      - You may want to initially commit the state up until now before the next
+        step, so that it's easier to compare the diff vs. the previous stable
+        release.
+      - Copy-paste the `.github` directory from the previous stable branch and
+        manually check the diff between the files from the current stable branch
+        and modify the workflows to match the target stable branch. See
+        [8bbae9cb43](https://github.com/cilium/cilium/commit/8bbae9cb4323bf3dd94936e355b0c2aad96d0df8)
+        for reference.
+      - Ignore all stable branch changes under the `.github/actions` directory.
+        `git checkout .github/actions`
+      - Remove the `labels-unset` field from the MLH configuration and add
+        the `auto-label` field. See [5b4934284d](https://github.com/cilium/cilium/commit/5b4934284dd525399aacec17c137811df9cf0f8b)
+        for reference.
+      - Rewrite the CODEOWNERS file. Keep the team descriptions from main
+        and the previous stable branch. See [97daf56221](https://github.com/cilium/cilium/commit/97daf5622197d0cdda003a3f693e6e5a61038884)
+      - Update CODEOWNERS documentation file by running `make -C Documentation update-codeowners`
+      - Replace references to `bpf-next-*` lvh images in workflows with the newest LTS kernel from [quay.io](https://quay.io/repository/lvh-images/kind?tab=tags&tag=latest).
+        `grep -R bpf-next- .github/workflows/`
+    - [ ] Review the diff for this commit compared to the preparation commit
+          for the previous stable branch.
+    - [ ] Push a PR with those changes:
+      - `git commit -sam "Prepare v1.10 stable branch"`
+      - `gh pr create -B v1.10`
+- [ ] Push a PR including the changes necessary for the new release:
+  - [ ] Run `../release/internal/start-release.sh v1.10.0-pre.0`
+        Note that this script produces some files at the root of the Cilium
+        repository, and that these files are required at a later step for
+        tagging the release.
+  - [ ] Check the modified schema file(s) in `Documentation` as it will be
+        necessary to fix them manually. Add a new line for this RC and remove
+        unsupported versions.
+  - [ ] Fix any duplicate `AUTHORS` entries and verify if it is possible to
+        get the real names instead of GitHub usernames.
+  - [ ] Add the generated `CHANGELOG.md` file and commit all remaining changes
+        with the title `Prepare for release v1.10.0-pre.0`
+  - [ ] Submit PR (`../release/internal/submit-release.sh`)
+- [ ] Merge PR
+- [ ] Ping current top-hat that PRs can be merged again.
+- [ ] Create and push *both* tags to GitHub (`v1.10.0-pre.0`, `1.10.0-pre.0`)
+  - Pull latest branch locally.
+  - Check out the release commit and run `../release/internal/tag-release.sh`
+    against that commit.
+- [ ] Ask a maintainer to approve the build in the following link (keep the URL
+      of the GitHub run to be used later):
+      [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
+  - [ ] Check if all docker images are available before announcing the release:
+        `make -C install/kubernetes/ RELEASE=yes CILIUM_BRANCH=v1.10 check-docker-images`
+- [ ] Get the image digests from the build process and make a commit and PR with
+      these digests.
+  - [ ] Run `../release/internal/post-release.sh URL` to fetch the image
+        digests and submit a PR to update these, use the `URL` of the GitHub
+        run here
+  - [ ] Get someone to review the PR. Do not trigger the full CI suite, but
+        wait for the automatic checks to complete. Merge the PR.
+- [ ] Update helm charts
+  - [ ] Create helm charts artifacts in [Cilium charts] repository using
+        [cilium helm release tool] for the `v1.10.0-pre.0` release and push these
+        changes into the helm repository.
+  - [ ] Check the output of the [chart workflow] and see if the test was
+        successful.
+- [ ] Check [read the docs] configuration:
+    - [ ] Set a new build as active and hidden in [active versions].
+    - [ ] Deactivate previous RCs.
+    - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
+      - Update the versions in `docsearch.config.json`, commit them and push a trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
+- [ ] Check draft release from [releases] page
+  - [ ] Update the text at the top with 2-3 highlights of the release
+  - [ ] Publish the release
+- [ ] Announce the release in #general on Slack.
+  Text template for the first RC:
+```
+*Announcement* :tada: :tada:
+
+:cilium-new: *Cilium release candidate v1.10.0-pre.0 has been released:*
+https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+
+This is the first monthly snapshot for the v1.10 development cycle. There are [v1.10.0-pre.0 OSS docs](https://docs.cilium.io/en/v1.10.0-pre.0) available if you want to pull this version & try it out.
+```
+Text template for the next RCs:
+```
+*Announcement* :tada: :tada:
+
+:cilium-new: *Cilium release candidate v1.10.0-pre.0 has been released:*
+https://github.com/cilium/cilium/releases/tag/v1.10.0-pre.0
+
+Thank you for the testing and contributing to the previous pre-releases. There are [v1.10.0-pre.0 OSS docs](https://docs.cilium.io/en/v1.10.0-pre.0) available if you want to pull this version & try it out.
+```
+- [ ] Bump the development snapshot version in `README.rst` on the main branch
+      to point to this release
+- [ ] Prepare post-release changes to main branch using `../release/internal/bump-readme.sh`.
+- [ ] Update the upgrade guide and [roadmap](https://github.com/cilium/cilium/blob/main/Documentation/community/roadmap.rst) for any features that changed status.
+
+[signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
+[release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2F1.10
+[backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2F1.10
+[Cilium charts]: https://github.com/cilium/charts
+[releases]: https://github.com/cilium/cilium/releases
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/RELEASE.md
+[cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
+[read the docs]: https://readthedocs.org/projects/cilium/
+[active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=v1.10.0-pre.0
+[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
+[chart workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml

--- a/testdata/checklist/release_template_rc_branch.md.input
+++ b/testdata/checklist/release_template_rc_branch.md.input
@@ -1,0 +1,1 @@
+../../.github/ISSUE_TEMPLATE/release_template_rc_branch.md


### PR DESCRIPTION
Fix a bug where release issue templates would be truncated before posting them
to GitHub whenever they included a horizontal separator (`---`).

While we're at it, add tests for the templating functionality to ensure that
the templates are processed correctly to generate issues with all version
numbers substituted. Use golden tests for this (generate with `make
generate-golden`). This also required updating the templates to match the
version substitutions supported by the checklist open command.

Review commit-by-commit.

Fixes: #256
Fixes: #261
