### PR TITLE
Include repo name in backport PR entries

### DIFF
--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -310,7 +310,7 @@ func (cl *ChangeLog) prReleaseNote(pr types.PullRequest, prNumber int, upstreamP
 	text := fmt.Sprintf("* %s", pr.ReleaseNote)
 	if !cl.ExcludePRReferences {
 		if upstreamPRNumber != nil {
-			text += fmt.Sprintf(" (Backport PR #%d, Upstream PR #%d, @%s)", prNumber, *upstreamPRNumber, pr.AuthorName)
+			text += fmt.Sprintf(" (Backport PR %s#%d, Upstream PR %s#%d, @%s)", cl.RepoName, prNumber, cl.RepoName, *upstreamPRNumber, pr.AuthorName)
 		} else {
 			text += fmt.Sprintf(" (%s#%d, @%s)", cl.RepoName, prNumber, pr.AuthorName)
 		}


### PR DESCRIPTION
I forgot to handle this case in #198.

Fixes: f56f58f7b409 ("Include repo name in release note entries")