### PR TITLE
Autodetect checklist template based on target version

### DIFF
--- a/.github/ISSUE_TEMPLATE/templates.go
+++ b/.github/ISSUE_TEMPLATE/templates.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Assets provides access to some top-level files into the tree.
+package templates
+
+import (
+	_ "embed"
+)
+
+var (
+	//go:embed release_template_minor.md
+	ReleaseTemplateMinor []byte
+
+	//go:embed release_template_patch.md
+	ReleaseTemplatePatch []byte
+
+	//go:embed release_template_pre_main.md
+	ReleaseTemplatePre []byte
+
+	//go:embed release_template_rc_branch.md
+	ReleaseTemplateRC []byte
+)

--- a/cmd/checklist/open.go
+++ b/cmd/checklist/open.go
@@ -92,7 +92,7 @@ func OpenCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/release", "GitHub organization and repository names separated by a slash to create the checklist in")
 	cmd.Flags().BoolVar(&cfg.DryRun, "dry-run", false, "Print the template, but do not open an issue on GitHub")
 
-	for _, flag := range []string{"target-version", "template"} {
+	for _, flag := range []string{"target-version"} {
 		cobra.MarkFlagRequired(cmd.Flags(), flag)
 	}
 	return cmd


### PR DESCRIPTION
This allows the tool to autodetect the right template based on
the specified version rather than having to specify the path,
for example `./release --version v1.17.0`.