### PR TITLE
bump-readme: Fix table misformatting detection

### DIFF
--- a/internal/bump-readme.sh
+++ b/internal/bump-readme.sh
@@ -73,7 +73,8 @@ main() {
     mv README.rst{.new,}
 
     update_stable_versions
-    check_table "releases/tag/v"
+    check_table "tree/v"
+    check_table "commits/v"
 
     git add README.rst stable.txt Documentation/_static/stable-version.json
     if ! git diff-index --quiet HEAD -- README.rst stable.txt Documentation/_static/stable-version.json; then


### PR DESCRIPTION
Before this commit, a single check for all lines matching a release
table would detect both the stable releases and development releases,
which have different table sizes. This would cause the script to
incorrectly inform the user that they need to check the malformed table.
Fix this by doing two separate checks, one for the stable release table
and one for the pre-release table.

Before:
```
$ ../cilium-release/internal/bump-readme.sh                                                                                                                             
The following table is malformed, please fix it:                                                                                                                                                                                
+---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+                                      
| `v1.17 <https://github.com/cilium/cilium/tree/v1.17>`__ | 2025-04-14 | ``quay.io/cilium/cilium:v1.17.3``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.17.3>`__  |                                      
+---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+                                      
| `v1.16 <https://github.com/cilium/cilium/tree/v1.16>`__ | 2025-04-14 | ``quay.io/cilium/cilium:v1.16.9``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.16.9>`__  |                                      
+---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+                                      
| `v1.15 <https://github.com/cilium/cilium/tree/v1.15>`__ | 2025-04-14 | ``quay.io/cilium/cilium:v1.15.16`` | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.15.16>`__ |                                      
+---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+                                      
--                                                                                                                                                                                                                              
+----------------------------------------------------------------------------+------------+-----------------------------------------+---------------------------------------------------------------------------------+         
| `v1.18.0-pre.2 <https://github.com/cilium/cilium/commits/v1.18.0-pre.2>`__ | 2025-05-01 | ``quay.io/cilium/cilium:v1.18.0-pre.2`` | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.18.0-pre.2>`__ |         
+----------------------------------------------------------------------------+------------+-----------------------------------------+---------------------------------------------------------------------------------+
```

After:
```
$ ../cilium-release/internal/bump-readme.sh                                                                                                                          
[pr/joe/bump-readme b1255617466e] README: Update releases 
 1 file changed, 1 insertion(+), 1 deletion(-)
README.rst and stable.txt updated, submit the PR now.
```

Fixes: cb7e519013c2 ("internal: Reimplement bump-readme.sh in Go")