### PR TITLE
.github: Synchronize release preparation steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_minor.md
+++ b/.github/ISSUE_TEMPLATE/release_template_minor.md
@@ -9,12 +9,16 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
-- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
-- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
+  each automated step does.
 
 ## Pre-check (run ~1 week before targeted publish date)
 

--- a/.github/ISSUE_TEMPLATE/release_template_patch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_patch.md
@@ -9,18 +9,15 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo,project) that has access to the repository. Only classic tokens are
-      [supported at the moment][GitHub PAT tracker], the needed scopes are `write:org`, `public_repo` and `project`.
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags]
-  with Git and install [gh](https://cli.github.com).
-- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
-  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
-    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
-
-          git checkout main && git pull && make
-- [ ] Read the documentation of `release start --help` tool to understand what
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
   each automated step does.
 
 ## Pre-check (run ~1 week before release date)

--- a/.github/ISSUE_TEMPLATE/release_template_pre_main.md
+++ b/.github/ISSUE_TEMPLATE/release_template_pre_main.md
@@ -9,18 +9,15 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo,project) that has access to the repository. Only classic tokens are
-      [supported at the moment][GitHub PAT tracker], the needed scopes are `write:org`, `public_repo` and `project`.
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags]
-  with Git and install [gh](https://cli.github.com).
-- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
-  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
-    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
-
-          git checkout master && git pull && make
-- [ ] Read the documentation of `release start --help` tool to understand what
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
   each automated step does.
 
 ## Pre-check (run ~1 week before release date)

--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -9,12 +9,16 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
-- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
-- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
+  each automated step does.
 
 ## Pre-release
 

--- a/testdata/checklist/release_template_minor.md.golden
+++ b/testdata/checklist/release_template_minor.md.golden
@@ -9,12 +9,16 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
-- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
-- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
+  each automated step does.
 
 ## Pre-check (run ~1 week before targeted publish date)
 

--- a/testdata/checklist/release_template_patch.md.golden
+++ b/testdata/checklist/release_template_patch.md.golden
@@ -9,18 +9,15 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo,project) that has access to the repository. Only classic tokens are
-      [supported at the moment][GitHub PAT tracker], the needed scopes are `write:org`, `public_repo` and `project`.
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags]
-  with Git and install [gh](https://cli.github.com).
-- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
-  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
-    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
-
-          git checkout main && git pull && make
-- [ ] Read the documentation of `release start --help` tool to understand what
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
   each automated step does.
 
 ## Pre-check (run ~1 week before release date)

--- a/testdata/checklist/release_template_pre_main.md.golden
+++ b/testdata/checklist/release_template_pre_main.md.golden
@@ -9,18 +9,15 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo,project) that has access to the repository. Only classic tokens are
-      [supported at the moment][GitHub PAT tracker], the needed scopes are `write:org`, `public_repo` and `project`.
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags]
-  with Git and install [gh](https://cli.github.com).
-- [ ] Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
-  - [ ] Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
-    - [ ] If you already have the repo checked out, make sure the `release` binary is up to date:
-
-          git checkout master && git pull && make
-- [ ] Read the documentation of `release start --help` tool to understand what
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
   each automated step does.
 
 ## Pre-check (run ~1 week before release date)

--- a/testdata/checklist/release_template_rc_branch.md.golden
+++ b/testdata/checklist/release_template_rc_branch.md.golden
@@ -9,12 +9,16 @@ assignees: ''
 
 ## Setup preparation
 
-- [ ] Depending on your OS, make sure Docker is running
-- [ ] Export a [`GITHUB_TOKEN`](https://github.com/settings/tokens/new?description=Cilium%20Release%20Script&scopes=write:org,public_repo) that has access to the repository
-- [ ] Make sure a setup (GPG, SSH, S/MIME) is in place for [signing tags] with Git
-- [ ] Make sure the `GOPATH` environment variable is set and pointing to the relevant path
-- [ ] Make sure the [Cilium helm charts][Cilium charts] repository is installed locally:
-  - [ ] Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+- Ensure Docker is installed and running
+- Ensure a setup is in place for [signing tags] with Git (GPG, SSH, S/MIME)
+- Install [gh](https://cli.github.com).
+- Make sure the [Cilium helm charts][Cilium charts] and [release][Cilium release-notes tool] repositories are installed locally:
+  - Run `git clone https://github.com/cilium/charts.git "$GOPATH/src/github.com/cilium/charts"`
+  - Run `git clone https://github.com/cilium/release.git "$GOPATH/src/github.com/cilium/release"`
+- [ ] Make sure the `release` binary is up to date:
+      `git checkout master && git pull && make`
+- Read the documentation of `release start --help` tool to understand what
+  each automated step does.
 
 ## Pre-release
 


### PR DESCRIPTION
For the vast majority of releases, release managers do not need to
manually check the checkboxes of all of these steps, so convert them
into a list instead. Keep the checkbox for updating the release tool as
it is essential to keep this up to date.

Two steps were unnecessary, remove them:
- `GITHUB_TOKEN` setup
- `GOPATH` setup

Update this section for all issue templates to ensure consistency.

Signed-off-by: Joe Stringer <joe@cilium.io>
