### PR TITLE
changelog: Add --exclude-labels flag

### DIFF
--- a/cmd/changelog/changelog.go
+++ b/cmd/changelog/changelog.go
@@ -23,6 +23,7 @@ type ChangeLogConfig struct {
 	StateFile           string
 	LabelFilters        []string
 	ReleaseLabels       []string
+	ExcludeLabels       []string
 	ExcludePRReferences bool
 	SkipHeader          bool
 }
@@ -69,6 +70,7 @@ func Command(ctx context.Context, logger *log.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.RepoName, "repo", "cilium/cilium", "GitHub organization and repository names separated by a slash")
 	cmd.Flags().StringArrayVar(&cfg.LabelFilters, "label-filter", []string{}, "Filter pull requests by labels.")
 	cmd.Flags().StringArrayVar(&cfg.ReleaseLabels, "release-labels", []string{}, "Specify release labels to consider when generating the changelog. This also defines the order of the release notes.")
+	cmd.Flags().StringArrayVar(&cfg.ExcludeLabels, "exclude-labels", []string{}, "Exclude pull requests with the specified labels.")
 	cmd.Flags().BoolVar(&cfg.ExcludePRReferences, "exclude-pr-references", false, "If true, do not include references to the PR or PR author")
 	cmd.Flags().BoolVar(&cfg.SkipHeader, "skip-header", false, "If true, do not print 'Summary of Changes' header")
 

--- a/cmd/changelog/generate.go
+++ b/cmd/changelog/generate.go
@@ -164,18 +164,24 @@ func (cl *ChangeLog) PrintReleaseNotesForWriter(w io.Writer) {
 		prsWithUpstream = make(types.BackportPRs)
 	)
 
-	// Filter the PRs by --label-filter
+	// Filter the PRs by --label-filter and --exclude-labels
 	for id, pr := range cl.listOfPrs.DeepCopy() {
 		if !filterByLabels(pr.Labels, cl.LabelFilters) {
+			continue
+		}
+		if len(cl.ExcludeLabels) > 0 && filterByLabels(pr.Labels, cl.ExcludeLabels) {
 			continue
 		}
 		listOfPRs[id] = pr
 	}
 
-	// Filter the Backport PRs by --label-filter
+	// Filter the Backport PRs by --label-filter and --exclude-labels
 	for prNumber, upstreamedPRs := range cl.prsWithUpstream.DeepCopy() {
 		for upstreamPRNumber, upstreamPR := range upstreamedPRs {
 			if !filterByLabels(upstreamPR.Labels, cl.LabelFilters) {
+				continue
+			}
+			if len(cl.ExcludeLabels) > 0 && filterByLabels(upstreamPR.Labels, cl.ExcludeLabels) {
 				continue
 			}
 			if prsWithUpstream[prNumber] == nil {
@@ -185,7 +191,7 @@ func (cl *ChangeLog) PrintReleaseNotesForWriter(w io.Writer) {
 		}
 	}
 
-	cl.Logger.Printf("Found %d PRs and %d backport PRs in %s based on --label-filter\n\n", len(listOfPRs), len(prsWithUpstream), cl.StateFile)
+	cl.Logger.Printf("Found %d PRs and %d backport PRs in %s\n\n", len(listOfPRs), len(prsWithUpstream), cl.StateFile)
 
 	if !cl.SkipHeader {
 		fmt.Fprintln(w, "Summary of Changes")

--- a/cmd/release/git.go
+++ b/cmd/release/git.go
@@ -244,11 +244,13 @@ func (pc *PrepareCommit) generateChangeLog(ctx context.Context, ghClient *GHClie
 	io2.Fprintf(3, os.Stdout, "✍️ Generating CHANGELOG.md from %s to %s\n", previousPatchVersion, commitSha)
 	io2.Fprintf(4, os.Stdout, "Previous and current version are from different branches, using last stable %q for release notes\n", lastStable)
 	clCfg := changelog.ChangeLogConfig{
-		CommonConfig: pc.cfg.CommonConfig,
-		Base:         previousPatchVersion,
-		Head:         commitSha,
-		StateFile:    pc.cfg.StateFile,
-		LastStable:   lastStable,
+		CommonConfig:  pc.cfg.CommonConfig,
+		Base:          previousPatchVersion,
+		Head:          commitSha,
+		StateFile:     pc.cfg.StateFile,
+		LastStable:    lastStable,
+		LabelFilters:  pc.cfg.IncludeLabels,
+		ExcludeLabels: pc.cfg.ExcludeLabels,
 	}
 	err = clCfg.Sanitize()
 	if err != nil {

--- a/cmd/release/start.go
+++ b/cmd/release/start.go
@@ -41,6 +41,9 @@ type ReleaseConfig struct {
 	StateFile            string
 	Steps                []string
 	DefaultBranch        string
+
+	IncludeLabels []string
+	ExcludeLabels []string
 }
 
 func (cfg *ReleaseConfig) Sanitize() error {
@@ -312,6 +315,8 @@ To start, run
 	cmd.Flags().StringSliceVar(&cfg.Steps, "steps", []string{"1"},
 		fmt.Sprintf("Specify which steps should be executed for the release. Steps numbers are also allowed, e.g. '1,2'. Accepted values: %s", strings.Join(allGroupStepsNames, ", ")),
 	)
+	cmd.Flags().StringArrayVar(&cfg.IncludeLabels, "include-labels", []string{}, "Include pull requests with these labels in generated changelogs")
+	cmd.Flags().StringArrayVar(&cfg.ExcludeLabels, "exclude-labels", []string{}, "Exclude pull requests with these labels from generated changelogs")
 
 	for _, flag := range []string{"target-version", "template"} {
 		cobra.MarkFlagRequired(cmd.Flags(), flag)


### PR DESCRIPTION
This will be useful to exclude certain PRs from changelogs when they are
unrelated to the target release.

Related: https://github.com/cilium/release/issues/272
