### PR TITLE
stable-branch: Document creating TESTOWNERS

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
+++ b/.github/ISSUE_TEMPLATE/release_template_rc_branch.md
@@ -173,6 +173,9 @@ assignees: ''
         for reference.
         - `cp {../cilium-X.Y-1/,}.github/maintainers-little-helper.yaml`
         - `sed -i 's/X.Y-1/X.Y/g' .github/maintainers-little-helper.yaml`
+      - Copy CODEOWNERS to TESTOWNERS.
+        - `cp CODEOWNERS TESTOWNERS`
+        - `git add TESTOWNERS`
       - Rewrite the CODEOWNERS file and docs. Keep the team descriptions from main
         and the previous stable branch. See [97daf56221](https://github.com/cilium/cilium/commit/97daf5622197d0cdda003a3f693e6e5a61038884)
         - `sed -i '/^\//,$d' CODEOWNERS`

--- a/testdata/checklist/release_template_rc_branch.md.golden
+++ b/testdata/checklist/release_template_rc_branch.md.golden
@@ -173,6 +173,9 @@ assignees: ''
         for reference.
         - `cp {../cilium-1.9/,}.github/maintainers-little-helper.yaml`
         - `sed -i 's/1.9/1.10/g' .github/maintainers-little-helper.yaml`
+      - Copy CODEOWNERS to TESTOWNERS.
+        - `cp CODEOWNERS TESTOWNERS`
+        - `git add TESTOWNERS`
       - Rewrite the CODEOWNERS file and docs. Keep the team descriptions from main
         and the previous stable branch. See [97daf56221](https://github.com/cilium/cilium/commit/97daf5622197d0cdda003a3f693e6e5a61038884)
         - `sed -i '/^\//,$d' CODEOWNERS`


### PR DESCRIPTION
Add a step to create the TESTOWNERS file which will be used to attribute
test failures to owners for workflows that run on the stable branch.

Signed-off-by: Joe Stringer <joe@cilium.io>
