### PR TITLE
Bump Go versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22.5 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.6 AS builder
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/cilium/release
 
-go 1.21
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
GitHub workflow runs are failing with the following error:

CGO_ENABLED=0 go build -ldflags="-s -w" -mod=vendor -o ./release ./cmd/main.go
go: go.mod requires go >= 1.23.0 (running go 1.22.5; GOTOOLCHAIN=local)
make: *** [Makefile:35: release] Error 1

Fix this by bumping the go.mod to match the version that is reportedly
required (probably implicitly required by one of the dependencies?) and
bumping the docker image to pull the latest oldstable release.
