### PR TITLE
release: change OCI registry

### DIFF
--- a/cmd/release/start.go
+++ b/cmd/release/start.go
@@ -221,7 +221,7 @@ To start, run
 
 			// Set default Helm OCI registries if not provided
 			if len(cfg.HelmOCIRegistries) == 0 {
-				cfg.HelmOCIRegistries = []string{"oci://quay.io/cilium", "oci://docker.io/cilium"}
+				cfg.HelmOCIRegistries = []string{"oci://quay.io/cilium/charts"}
 			}
 
 			// check if docker is running before starting the release process


### PR DESCRIPTION
Change OCI registry to quay.io/cilium/charts/cilium to avoid semver conflicts between cilium container images and helm charts.

Cousin PRs:
https://github.com/cilium/cilium/pull/43646
https://github.com/cilium/charts/pull/227
