### PR TITLE
.github: Remove Algolia DocSearch release steps

### DIFF
--- a/.github/templates/release_template_minor.md
+++ b/.github/templates/release_template_minor.md
@@ -75,9 +75,6 @@ assignees: ''
         hidden and configure the new minor version as active and **not**
         hidden in [active versions].
   - [ ] Deactivate previous RCs.
-  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
-    - Update the versions in `docsearch.config.json`, commit them and push a
-      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
 
 ## Post-release
 
@@ -120,7 +117,6 @@ assignees: ''
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=vX.Y
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [Charts Workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml
 [Cilium charts]: https://github.com/cilium/charts
 [default version]: https://readthedocs.org/dashboard/cilium/advanced/

--- a/.github/templates/release_template_pre_main.md
+++ b/.github/templates/release_template_pre_main.md
@@ -75,9 +75,6 @@ assignees: ''
 
 - [ ] Check [read the docs] configuration:
   - [ ] Deactivate [previous RCs].
-  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
-    - Update the versions in `docsearch.config.json`, commit them and push a
-      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
 
 ## Post-release
 
@@ -121,7 +118,6 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 ```
 
 [previous RCs]: https://app.readthedocs.org/projects/cilium/?slug=&privacy=public&visibility=hidden&sort=
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml
 [GitHub PAT tracker]: https://github.com/orgs/community/discussions/36441
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags

--- a/.github/templates/release_template_rc_branch.md
+++ b/.github/templates/release_template_rc_branch.md
@@ -292,9 +292,6 @@ assignees: ''
 - [ ] Check [read the docs] configuration:
   - [ ] Set a new build as active and hidden in [active versions].
   - [ ] Deactivate previous RCs.
-  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
-    - Update the versions in `docsearch.config.json`, commit them and push a
-      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
 
 ## Post-release
 
@@ -344,7 +341,6 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=vX.Y.Z-rc.W
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [Charts Workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml
 [Cilium charts]: https://github.com/cilium/charts
 [Review feature PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+base%3Amain+is%3Apr+-label%3Arelease-note%2Fbug+-label%3Arelease-note%2Fci+-author%3Aapp%2Fcilium-renovate+-label%3Adont-merge%2Fwait-until-release+-label%3Adont-merge%2Fpreview-only+-label%3Aarea%2Fdocumentation+-label%3Acilium-cli-exclusive+-label%3Arelease-blocker%2FX.Y

--- a/testdata/checklist/release_template_minor.md.golden
+++ b/testdata/checklist/release_template_minor.md.golden
@@ -75,9 +75,6 @@ assignees: ''
         hidden and configure the new minor version as active and **not**
         hidden in [active versions].
   - [ ] Deactivate previous RCs.
-  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
-    - Update the versions in `docsearch.config.json`, commit them and push a
-      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
 
 ## Post-release
 
@@ -120,7 +117,6 @@ assignees: ''
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=v1.10
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [Charts Workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml
 [Cilium charts]: https://github.com/cilium/charts
 [default version]: https://readthedocs.org/dashboard/cilium/advanced/

--- a/testdata/checklist/release_template_pre_main.md.golden
+++ b/testdata/checklist/release_template_pre_main.md.golden
@@ -75,9 +75,6 @@ assignees: ''
 
 - [ ] Check [read the docs] configuration:
   - [ ] Deactivate [previous RCs].
-  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
-    - Update the versions in `docsearch.config.json`, commit them and push a
-      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
 
 ## Post-release
 
@@ -121,7 +118,6 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 ```
 
 [previous RCs]: https://app.readthedocs.org/projects/cilium/?slug=&privacy=public&visibility=hidden&sort=
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml
 [GitHub PAT tracker]: https://github.com/orgs/community/discussions/36441
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags

--- a/testdata/checklist/release_template_rc_branch.md.golden
+++ b/testdata/checklist/release_template_rc_branch.md.golden
@@ -292,9 +292,6 @@ assignees: ''
 - [ ] Check [read the docs] configuration:
   - [ ] Set a new build as active and hidden in [active versions].
   - [ ] Deactivate previous RCs.
-  - [ ] Update algolia configuration search in [docsearch-scraper-webhook].
-    - Update the versions in `docsearch.config.json`, commit them and push a
-      trigger the workflow [here](https://github.com/cilium/docsearch-scraper-webhook/actions/workflows/update-algolia-index.yaml)
 
 ## Post-release
 
@@ -344,7 +341,6 @@ Thank you for the testing and contributing to the previous pre-releases. There a
 [cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime
 [read the docs]: https://readthedocs.org/projects/cilium/
 [active versions]: https://readthedocs.org/projects/cilium/versions/?version_filter=v1.10.0-pre.0
-[docsearch-scraper-webhook]: https://github.com/cilium/docsearch-scraper-webhook
 [Charts Workflow]: https://github.com/cilium/charts/actions/workflows/validate-cilium-chart.yaml
 [Cilium charts]: https://github.com/cilium/charts
 [Review feature PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+base%3Amain+is%3Apr+-label%3Arelease-note%2Fbug+-label%3Arelease-note%2Fci+-author%3Aapp%2Fcilium-renovate+-label%3Adont-merge%2Fwait-until-release+-label%3Adont-merge%2Fpreview-only+-label%3Aarea%2Fdocumentation+-label%3Acilium-cli-exclusive+-label%3Arelease-blocker%2F1.10


### PR DESCRIPTION
Algolia DocSearch usage for the docs is being retired, so we no longer
need to modify that repository when making new (pre, minor) releases.

Blocked by: https://github.com/cilium/sphinx_rtd_theme/pull/30
Blocked by: https://github.com/cilium/cilium/pull/45289 (+backports)