### PR TITLE
Dockerfile: Bump Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.6 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.9 AS builder
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Bump Go to the most recent stable in the previous release series to fix the
GitHub actions build.
