### PR TITLE
minor: Add process to manage blocker labels

### DIFF
--- a/.github/templates/release_template_minor.md
+++ b/.github/templates/release_template_minor.md
@@ -106,8 +106,13 @@ assignees: ''
 - [ ] Update the [Cilium Wikipedia] release timeline table to reflect the new
       version. Ensure the version, release date, and any notable changes are
       accurately represented in the table and graph.
+- [ ] Add [release-blocker labels] for the two upcoming minor release versions.
+  - [ ] Update the [release-blocker project automation] to auto-add issues to
+        the project when the issue is labeled with a release-blocker label.
 
 [release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml
+[release-blocker labels]: https://github.com/cilium/cilium/labels?q=release-blocker/
+[release-blocker project automation]: https://github.com/orgs/cilium/projects/51/workflows
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2FX.Y
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2FX.Y

--- a/testdata/checklist/release_template_minor.md.golden
+++ b/testdata/checklist/release_template_minor.md.golden
@@ -106,8 +106,13 @@ assignees: ''
 - [ ] Update the [Cilium Wikipedia] release timeline table to reflect the new
       version. Ensure the version, release date, and any notable changes are
       accurately represented in the table and graph.
+- [ ] Add [release-blocker labels] for the two upcoming minor release versions.
+  - [ ] Update the [release-blocker project automation] to auto-add issues to
+        the project when the issue is labeled with a release-blocker label.
 
 [release workflow]: https://github.com/cilium/cilium/actions/workflows/release.yaml
+[release-blocker labels]: https://github.com/cilium/cilium/labels?q=release-blocker/
+[release-blocker project automation]: https://github.com/orgs/cilium/projects/51/workflows
 [signing tags]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2F1.10
 [backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2F1.10


### PR DESCRIPTION
We don't necessarily need to do this exactly at the patch release time,
but in the absence of another clear trigger to go through these steps,
add the instruction here.