### PR TITLE
.github/templates: exclude cilium-cli-exclusive PRs from minor changelog

### DIFF
--- a/.github/templates/release_template_minor.md
+++ b/.github/templates/release_template_minor.md
@@ -35,7 +35,7 @@ assignees: ''
 
 ## Preparation PR (run ~1 day before targeted publish date. This step can be re-run multiple times.)
 
-- [ ] Run `./release start --steps 2-prepare-release --target-version vX.Y.0`
+- [ ] Run `./release start --steps 2-prepare-release --target-version vX.Y.0 --exclude-labels "cilium-cli-exclusive"`
 - [ ] Manually fix the following:
   - [ ] Add the 'stable' tag as part of the GitHub workflow and remove the
         'stable' tag from the last stable branch (vX.Y-1).

--- a/testdata/checklist/release_template_minor.md.golden
+++ b/testdata/checklist/release_template_minor.md.golden
@@ -35,7 +35,7 @@ assignees: ''
 
 ## Preparation PR (run ~1 day before targeted publish date. This step can be re-run multiple times.)
 
-- [ ] Run `./release start --steps 2-prepare-release --target-version v1.10.0`
+- [ ] Run `./release start --steps 2-prepare-release --target-version v1.10.0 --exclude-labels "cilium-cli-exclusive"`
 - [ ] Manually fix the following:
   - [ ] Add the 'stable' tag as part of the GitHub workflow and remove the
         'stable' tag from the last stable branch (v1.9).


### PR DESCRIPTION
The minor release template is the only one that runs `2-prepare-release`
locally. The other templates (`patch`, `pre_main`, `rc_branch`) route that
step through the [release workflow] in `cilium/cilium`, which already passes
`--exclude-labels "cilium-cli-exclusive"` on every `./release start`
invocation.

Without the flag, a local run of step 2 picks up PRs labeled
`cilium-cli-exclusive` in the generated changelog, so the output differs from
what CI would have produced for the same release.

Regenerated `testdata/checklist/release_template_minor.md.golden` via
`make generate-golden`. Only the minor golden changed — the `.input` files are
symlinks to the real templates and only that one template was modified.

[release workflow]: https://github.com/cilium/cilium/blob/main/.github/workflows/release.yaml