### PR TITLE
cmd/release: don't read pr-body file in post-release step

### DIFF
--- a/cmd/release/post-release_pull_request.go
+++ b/cmd/release/post-release_pull_request.go
@@ -60,26 +60,13 @@ func (pc *PustPostPullRequest) Run(ctx context.Context, yesToPrompt, dryRun bool
 	majorMinor := semver.MajorMinor(pc.cfg.TargetVer)
 	isMinorRelease := strings.TrimPrefix(pc.cfg.TargetVer, majorMinor) == ".0"
 	if isMinorRelease {
+		// The full changelog of a minor release would exceed the maximum size
+		// of a GitHub release body, so use the same short body as the
+		// "Prepare for release" PR and leave it up to the maintainers to
+		// replace it with the release announcement.
 		const instructionMsg = "<!-- Copy the slack announcement message to here and adapt emojis -->\n\n"
-		if _, err := releaseSummaryFileContent.WriteString(instructionMsg); err != nil {
+		if _, err := releaseSummaryFileContent.WriteString(instructionMsg + prBodyMsg); err != nil {
 			return fmt.Errorf("unable to write instruction message to release summary file: %w", err)
-		}
-
-		// For minor releases, use the -pr-body.txt file
-		prBodyFileName := fmt.Sprintf("%s-pr-body.txt", pc.cfg.TargetVer)
-		prBodyFile := filepath.Join(pc.cfg.RepoDirectory, prBodyFileName)
-		prBodyFileContent, err := os.Open(prBodyFile)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("error reading %s file: %w", prBodyFileName, err)
-			} else {
-				return fmt.Errorf("%s file not found, it needs to be present to create a release on GitHub for minor releases", prBodyFileName)
-			}
-		}
-		defer prBodyFileContent.Close()
-
-		if _, err := io.Copy(releaseSummaryFileContent, prBodyFileContent); err != nil {
-			return fmt.Errorf("unable to copy the pr-body file content into the release summary file: %w", err)
 		}
 	} else {
 		// Generate release summary

--- a/cmd/release/pull_request.go
+++ b/cmd/release/pull_request.go
@@ -16,6 +16,11 @@ import (
 	github2 "github.com/google/go-github/v62/github"
 )
 
+// prBodyMsg is the body used for the "Prepare for release" PR. It is also
+// re-used as the body of the draft GitHub release for minor releases, since
+// the full changelog would exceed the maximum size of a release body.
+const prBodyMsg = "\nSee the included CHANGELOG.md for a full list of changes.\n"
+
 type PushPullRequest struct {
 	cfg *ReleaseConfig
 }
@@ -144,7 +149,7 @@ func (pc *PushPullRequest) generateSummaryFile() (string, string, error) {
 	}
 	defer prBodyFileContent.Close()
 
-	prBodyFileContent.WriteString("\nSee the included CHANGELOG.md for a full list of changes.\n")
+	prBodyFileContent.WriteString(prBodyMsg)
 
 	return prTitle, prBodyFileName, err
 }


### PR DESCRIPTION
The 4-post-release step failed for v1.20.0 with "v1.20.0-pr-body.txt file not found, it needs to be present to create a release on GitHub for minor releases" (https://github.com/cilium/cilium/actions/runs/30454869041/job/90589118380). That file is a local scratch file written by PushPullRequest.generateSummaryFile() during 2-prepare-release. It is never committed, and release.yaml passes nothing between steps via artifacts, so 4-post-release runs in a separate job with a fresh actions/checkout — a day later in this case — and the file can never exist there. Only minor releases are affected: 85cd002 added a minor-release-only branch that reads it, while patches and pre-releases keep generating the body from CHANGELOG.md, and v1.20.0 is the first .0 release since that commit landed. The failed run produced nothing durable, since the digests commit was made locally but never pushed, so there is no pr/v1.20.0-digests branch, no digests PR and no draft v1.20.0 release.

The file only ever contains a single static line, so this writes that line inline instead of reading it back from disk, and shares it as a constant between the two call sites so the PR body and the release body cannot drift apart. The resulting draft release body for a minor release is the instruction comment, then "See the included CHANGELOG.md for a full list of changes.", then the digests. That matches the intent of 85cd002: the full changelog of a minor release exceeds GitHub's release body limit, with the v1.19.0 section measuring roughly 141 KB against a 125,000 character cap, so maintainers replace the stub with the Slack announcement by hand.

gofmt, go build ./... and go vet ./cmd/... are clean and go test ./... passes. Patch releases are untouched, verified against the shipped v1.19.6 release whose 12,221 character body is generated from CHANGELOG.md by the unchanged else branch. One pre-existing caveat this does not address: the patch path assumes "## v<target>" is the topmost heading in CHANGELOG.md, so re-running 4-post-release before step 2's changelog commit has merged into the stable branch would silently carry the previous patch's changelog rather than failing loudly.

Once this merges, re-dispatching release.yaml with step 4-post-release and version v1.20.0 should complete the release. No cilium-side change is needed, because the workflow checks out cilium/release at main on every run, and no backport is needed as this repository has no stable branches.
